### PR TITLE
passing context instead of storing within the layer as those are shared

### DIFF
--- a/Sources/Neuron/Layers/Activations/Softmax.swift
+++ b/Sources/Neuron/Layers/Activations/Softmax.swift
@@ -37,7 +37,7 @@ public final class Softmax: BaseActivationLayer {
                encodingType: .softmax)
   }
   
-  public override func forward(tensor: Tensor) -> Tensor {
+  public override func forward(tensor: Tensor, context: NetworkContext = .init()) -> Tensor {
     let context = TensorContext { inputs, gradient in
       return (Tensor(gradient.value), Tensor(), Tensor())
     }

--- a/Sources/Neuron/Layers/AvgPool.swift
+++ b/Sources/Neuron/Layers/AvgPool.swift
@@ -38,7 +38,7 @@ public final class AvgPool: BaseLayer {
     try container.encode(encodingType, forKey: .type)
   }
   
-  public override func forward(tensor: Tensor) -> Tensor {
+  public override func forward(tensor: Tensor, context: NetworkContext = .init()) -> Tensor {
     func backwards(input: Tensor, gradient: Tensor) -> (Tensor, Tensor, Tensor) {
       var poolingGradients: [[[Tensor.Scalar]]] = []
       

--- a/Sources/Neuron/Layers/BatchNormalize.swift
+++ b/Sources/Neuron/Layers/BatchNormalize.swift
@@ -91,7 +91,7 @@ public final class BatchNormalize: BaseLayer {
     try container.encode(momentum, forKey: .momentum)
   }
 
-  public override func forward(tensor: Tensor) -> Tensor {
+  public override func forward(tensor: Tensor, context: NetworkContext = .init()) -> Tensor {
     let context = TensorContext { inputs, gradient in
       let backward = self.backward(inputs: inputs.value, gradient: gradient.value)
       return (Tensor(backward), Tensor(), Tensor())

--- a/Sources/Neuron/Layers/Conv2d.swift
+++ b/Sources/Neuron/Layers/Conv2d.swift
@@ -96,7 +96,7 @@ public class Conv2d: BaseConvolutionalLayer {
     outputSize = TensorSize(array: [columns, rows, filterCount])
   }
   
-  public override func forward(tensor: Tensor) -> Tensor {
+  public override func forward(tensor: Tensor, context: NetworkContext = .init()) -> Tensor {
     let context = TensorContext { inputs, gradient in
       self.backward(inputs, gradient)
     }

--- a/Sources/Neuron/Layers/Dense.swift
+++ b/Sources/Neuron/Layers/Dense.swift
@@ -99,7 +99,7 @@ public final class Dense: BaseLayer {
     weights = Tensor(newWeights)
   }
   
-  public override func forward(tensor: Tensor) -> Tensor {
+  public override func forward(tensor: Tensor, context: NetworkContext) -> Tensor {
     
     let tensorContext = TensorContext { inputs, gradients in
       let gradientsFlat: [Tensor.Scalar] = gradients.value.flatten()

--- a/Sources/Neuron/Layers/Dropout.swift
+++ b/Sources/Neuron/Layers/Dropout.swift
@@ -52,7 +52,7 @@ public final class Dropout: BaseLayer {
     try container.encode(mask, forKey: .mask)
   }
   
-  public override func forward(tensor: Tensor) -> Tensor {
+  public override func forward(tensor: Tensor, context: NetworkContext = .init()) -> Tensor {
     let context = TensorContext { inputs, gradient in
       let droppedOutGradients = gradient * self.mask
       

--- a/Sources/Neuron/Layers/Embedding/Embedding.swift
+++ b/Sources/Neuron/Layers/Embedding/Embedding.swift
@@ -81,7 +81,7 @@ public final class Embedding: BaseLayer {
   /// Forward path for the layer
   /// - Parameter tensor: Input word as a 3D tensor with size `rows: 1, columns: vocabSize, depth: batchLength`
   /// - Returns: An output 3D tensor of shape `rows: 1, columns: inputUnits, depth: batchLength`
-  public override func forward(tensor: Tensor) -> Tensor {
+  public override func forward(tensor: Tensor, context: NetworkContext = .init()) -> Tensor {
     let context = TensorContext { inputs, gradient in
       var wrtEmbeddings: Tensor = Tensor()
 

--- a/Sources/Neuron/Layers/Flatten.swift
+++ b/Sources/Neuron/Layers/Flatten.swift
@@ -43,7 +43,7 @@ public final class Flatten: BaseLayer {
     try container.encode(encodingType, forKey: .type)
   }
   
-  public override func forward(tensor: Tensor) -> Tensor {
+  public override func forward(tensor: Tensor, context: NetworkContext = .init()) -> Tensor {
     let context = TensorContext { inputs, gradient in
       
       let inputSize = self.inputSize

--- a/Sources/Neuron/Layers/LSTM/LSTMCell.swift
+++ b/Sources/Neuron/Layers/LSTM/LSTMCell.swift
@@ -99,6 +99,7 @@ class LSTMCell {
   }
   
   func forward(tensor: Tensor,
+               context: NetworkContext,
                parameters: Parameters,
                cache: LSTM.Cache) -> Activations {
     
@@ -114,23 +115,23 @@ class LSTMCell {
     
     // forget gate
     let fa = device.matmul(concat, fgw) + parameters.forgetGateBiases.asScalar()
-    let faOut = Sigmoid().forward(tensor: fa)
+    let faOut = Sigmoid().forward(tensor: fa, context: context)
     
     // input gate
     let ia = device.matmul(concat, igw) + parameters.inputGateBiases.asScalar()
-    let iaOut = Sigmoid().forward(tensor: ia)
+    let iaOut = Sigmoid().forward(tensor: ia, context: context)
     
     // gate gate
     let ga = device.matmul(concat, ggw) + parameters.gateGateBiases.asScalar()
-    let gaOut = Tanh().forward(tensor: ga)
+    let gaOut = Tanh().forward(tensor: ga, context: context)
     
     // output gate
     let oa = device.matmul(concat, ogw) + parameters.outputGateBiases.asScalar() // Could be Dense layers
-    let oaOut = Sigmoid().forward(tensor: oa)
+    let oaOut = Sigmoid().forward(tensor: oa, context: context)
     
     let cellMemoryMatrix = (faOut * previousCellMatrix) + (iaOut * gaOut)
     
-    let tanOut = Tanh().forward(tensor: cellMemoryMatrix)
+    let tanOut = Tanh().forward(tensor: cellMemoryMatrix, context: context)
     
     let activationMatrix = oaOut * tanOut
     

--- a/Sources/Neuron/Layers/Layer.swift
+++ b/Sources/Neuron/Layers/Layer.swift
@@ -49,7 +49,6 @@ public protocol ConvolutionalLayer: Layer {
 
 /// The the object that perform ML operations
 public protocol Layer: AnyObject, Codable {
-  var threadId: Int { get set }
   var encodingType: EncodingType { get set }
   var extraEncodables: [String: Codable]? { get }
   var inputSize: TensorSize { get set }
@@ -62,7 +61,7 @@ public protocol Layer: AnyObject, Codable {
   var initializer: Initializer? { get }
   var device: Device { get set }
   var usesOptimizer: Bool { get set }
-  func forward(tensor: Tensor) -> Tensor
+  func forward(tensor: Tensor, context: NetworkContext) -> Tensor
   func apply(gradients: Optimizer.Gradient, learningRate: Tensor.Scalar)
   func exportWeights() throws -> [Tensor]
   func importWeights(_ weights: [Tensor]) throws
@@ -89,7 +88,6 @@ extension Layer {
 }
 
 open class BaseLayer: Layer {
-  public var threadId: Int = 0
   public var encodingType: EncodingType
   public var inputSize: TensorSize = .init() {
     didSet {
@@ -132,7 +130,7 @@ open class BaseLayer: Layer {
   }
   
   
-  public func forward(tensor: Tensor) -> Tensor {
+  public func forward(tensor: Tensor, context: NetworkContext) -> Tensor {
     // override
     .init()
   }
@@ -314,7 +312,7 @@ open class BaseActivationLayer: BaseLayer, ActivationLayer {
               encodingType: .none)
   }
   
-  public override func forward(tensor: Tensor) -> Tensor {
+  public override func forward(tensor: Tensor, context: NetworkContext = .init()) -> Tensor {
     
     let context = TensorContext { inputs, gradient in
       let out = self.device.derivate(inputs, self.type).value * gradient.value

--- a/Sources/Neuron/Layers/LayerNormalize.swift
+++ b/Sources/Neuron/Layers/LayerNormalize.swift
@@ -81,7 +81,7 @@ public final class LayerNormalize: BaseLayer {
     try container.encode(epsilon, forKey: .epsilon)
   }
   
-  public override func forward(tensor: Tensor) -> Tensor {
+  public override func forward(tensor: Tensor, context: NetworkContext = .init()) -> Tensor {
     let context = TensorContext { inputs, gradient in
       let gradient = self.backward(inputs: inputs.value, gradient: gradient.value)
       return (Tensor(gradient), Tensor(), Tensor())

--- a/Sources/Neuron/Layers/MaxPool.swift
+++ b/Sources/Neuron/Layers/MaxPool.swift
@@ -53,7 +53,7 @@ public final class MaxPool: BaseLayer {
     try container.encode(encodingType, forKey: .type)
   }
   
-  public override func forward(tensor: Tensor) -> Tensor {
+  public override func forward(tensor: Tensor, context: NetworkContext = .init()) -> Tensor {
     func backwards(input: Tensor, gradient: Tensor) -> (Tensor, Tensor, Tensor) {
       let deltas = gradient.value
       var poolingGradients: [[[Tensor.Scalar]]] = []

--- a/Sources/Neuron/Layers/Reshape.swift
+++ b/Sources/Neuron/Layers/Reshape.swift
@@ -52,7 +52,7 @@ public final class Reshape: BaseLayer {
     try container.encode(encodingType, forKey: .type)
   }
   
-  public override func forward(tensor: Tensor) -> Tensor {
+  public override func forward(tensor: Tensor, context: NetworkContext = .init()) -> Tensor {
     let context = TensorContext { inputs, gradient in
       let value: [Tensor.Scalar] = gradient.value.flatten()
       return (Tensor(value), Tensor(), Tensor())

--- a/Sources/Neuron/Optimizers/Optimizer.swift
+++ b/Sources/Neuron/Optimizers/Optimizer.swift
@@ -130,7 +130,7 @@ open class BaseOptimizer: Optimizer {
 
     data.concurrentForEach(workers: min(Constants.maxWorkers, Int(ceil(Double(data.count) / Double(4)))),
                            priority: device.qosPriority) { tensor, index in
-      let output = self.trainable.predict(tensor)
+      let output = self.trainable.predict(tensor, context: .init(threadId: index))
       results[index] = output
     }
 
@@ -160,8 +160,7 @@ open class BaseOptimizer: Optimizer {
       let label: [Tensor.Scalar] = labels[index].value.flatten()
       let input = data[index]
       
-      self.trainable.threadId = index
-      let out = self.trainable.predict(input)
+      let out = self.trainable.predict(input, context: .init(threadId: index))
       
       outputs[index] = out
             

--- a/Sources/Neuron/Trainable/Trainable.swift
+++ b/Sources/Neuron/Trainable/Trainable.swift
@@ -11,9 +11,6 @@ import NumSwiftC
 ///
 public protocol Trainable: AnyObject, Codable, CustomDebugStringConvertible {
   
-  /// The id for the current thread
-  var threadId: Int { get set }
-  
   /// Generic name of the trainable. Used when printing the network
   var name: String { get set }
   
@@ -37,7 +34,7 @@ public protocol Trainable: AnyObject, Codable, CustomDebugStringConvertible {
   /// Performs a forward pass on the network
   /// - Parameter data: The inputs
   /// - Returns: The output of the network
-  func predict(_ data: Tensor) -> Tensor
+  func predict(_ data: Tensor, context: NetworkContext) -> Tensor
   
   /// Compiles the network, getting it ready to be trained.
   func compile()

--- a/Sources/Neuron/Utilities/Storage.swift
+++ b/Sources/Neuron/Utilities/Storage.swift
@@ -17,6 +17,15 @@ public final class ThreadStorage<T> {
     }
   }
   
+  public func clear() {
+    defer {
+      lock.unlock()
+    }
+    lock.with {
+      storage.removeAll()
+    }
+  }
+  
   public func value(at: Int) -> T? {
     defer {
       lock.unlock()

--- a/Tests/NeuronTests/FullModelTests.swift
+++ b/Tests/NeuronTests/FullModelTests.swift
@@ -178,10 +178,10 @@ final class FullModelTests: XCTestCase {
   
   /// LSTM test example
   func test_LSTM_Forward_Example() async {
-//    guard isGithubCI == false else {
-//      XCTAssertTrue(true)
-//      return
-//    }
+    guard isGithubCI == false else {
+      XCTAssertTrue(true)
+      return
+    }
 
     let inputUnits = 50
     let hiddenUnits = 100

--- a/Tests/NeuronTests/FullModelTests.swift
+++ b/Tests/NeuronTests/FullModelTests.swift
@@ -178,10 +178,10 @@ final class FullModelTests: XCTestCase {
   
   /// LSTM test example
   func test_LSTM_Forward_Example() async {
-    guard isGithubCI == false else {
-      XCTAssertTrue(true)
-      return
-    }
+//    guard isGithubCI == false else {
+//      XCTAssertTrue(true)
+//      return
+//    }
 
     let inputUnits = 50
     let hiddenUnits = 100

--- a/Tests/NeuronTests/LayerTests.swift
+++ b/Tests/NeuronTests/LayerTests.swift
@@ -501,7 +501,7 @@ final class LayerTests: XCTestCase {
                     vocabSize: vocabSize)
 
         
-    let out = lstm.forward(tensor: embeddingCalc)
+    let out = lstm.forward(tensor: embeddingCalc, context: .init())
     
     XCTAssertEqual(out.shape, [vocabSize, 1, batchLength])
   }

--- a/scripts/Neuron.xctemplate/___VARIABLE_productName___/___VARIABLE_productName___.swift
+++ b/scripts/Neuron.xctemplate/___VARIABLE_productName___/___VARIABLE_productName___.swift
@@ -39,7 +39,7 @@ public final class ___VARIABLE_productName___: BaseLayer {
     try container.encode(encodingType, forKey: .type)
   }
   
-  public override func forward(tensor: Tensor) -> Tensor {
+  public override func forward(tensor: Tensor, context: NetworkContext) -> Tensor {
     let context = TensorContext { inputs, gradient in
       // backpropogation calculation
       return (Tensor(), Tensor(), Tensor())


### PR DESCRIPTION
Initially `threadId` was a property on the layer. However this could cause an issue because all layers can be run in parallel. It was unpredictable as to what that value of the threadId would be at runtime. Passing in the context allows the layers to have a reference to the current threadId they are running on allowing for same threads to have a shared state. 