### PR TITLE
Auto discover best number of workers for CPU

### DIFF
--- a/Sources/Neuron/Constants.swift
+++ b/Sources/Neuron/Constants.swift
@@ -8,5 +8,27 @@
 import Foundation
 
 public struct Constants {
-  public static let maxWorkers: Int = 4
+  public static var maxWorkers: Int = {
+    if let perfCores = getSysctlIntValue("hw.perflevel0.physicalcpu") {
+      // find closest power of 2 as batch sizes are usually broken up in powers of 2. Eg. 16, 32, 64
+      // this allows for a better split of the work between threads as it's evenly divisible.
+      return 1 << (Int(log2(Double(perfCores))))
+    } else {
+      return 4
+    }
+  }()
+  
+  static func getSysctlIntValue(_ name: String) -> Int? {
+    var size = 0
+    sysctlbyname(name, nil, &size, nil, 0)
+    var result = 0
+    let resultPointer = UnsafeMutableRawPointer.allocate(byteCount: size, alignment: MemoryLayout<Int>.alignment)
+    defer { resultPointer.deallocate() }
+    if sysctlbyname(name, resultPointer, &size, nil, 0) == 0 {
+      result = resultPointer.load(as: Int.self)
+      return result
+    }
+    return nil
+  }
+
 }


### PR DESCRIPTION
About a 1.5x speed increase on an M4 Max MBP. 

```swift
    let classes = 3
    let size = [28,28,1]
    
    let network = Sequential {
      [
        Conv2d(filterCount: 64,
               inputSize: TensorSize(array: size),
               padding: .same,
               initializer: initializer),
        ReLu(),
        MaxPool(),
        Conv2d(filterCount: 128,
               padding: .same,
               initializer: initializer),
        ReLu(),
        MaxPool(),
        Flatten(),
        Dense(64, initializer: initializer),
        ReLu(),
        Dense(classes, initializer: initializer),
        Softmax()
      ]
    }
```

Batch size of `32`