### PR TITLE
Migrate Tensor ops to pointer-based autograd broadcasting

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -30,6 +30,18 @@ alwaysApply: true
 - Feature branches should be created off `develop`
 - `main` is only updated via merges from `develop`
 
+### Tensor Self-Assignment:
+- **NEVER** write `tensor = tensor op value` where `op` is `+`, `-`, `*`, or `/` on Tensor types. The autograd operators build a computation graph that references the old tensor, creating a reference cycle when assigned back to the same variable.
+- Instead, drop the autograd context by constructing a new Tensor from the result's storage:
+  ```swift
+  // BAD: gamma = gamma - gradients  (reference cycle!)
+  // GOOD:
+  gamma = Tensor(storage: (gamma - gradients).storage, size: gamma.size)
+  // ALSO GOOD (TensorStorage arithmetic has no autograd):
+  gamma = Tensor(storage: gamma.storage - gradients.storage, size: gamma.size)
+  ```
+- This applies to any layer property (gamma, beta, movingMean, etc.) updated via arithmetic referencing itself.
+
 ### Performance:
 - Use `NumSwiftFlat` pointer APIs (e.g., `NumSwiftFlat.mul`, `add`, `sub`, `div`, `sqrt`, `sum`) for all element-wise arithmetic in hot paths instead of `Tensor.Value` operator overloads
 - Allocate output buffers with `TensorStorage.create(count:)` instead of `Tensor.Value(repeating:count:)`

--- a/.cursor/rules/layer.mdc
+++ b/.cursor/rules/layer.mdc
@@ -98,5 +98,6 @@ public final class [LayerName]: BaseLayer {
 4. **Device Support**: Inherit device management from BaseLayer
 5. **Codable**: Implement proper encoding/decoding for model persistence
 6. **Pointer-Based Arithmetic**: Use `TensorStorage.create(count:)` for output buffers, `NumSwiftFlat` pointer APIs for element-wise math, and `Tensor(storage:size:)` to construct output tensors. Access depth slices via `tensor.depthPointer(d)` or `tensor.storage.pointer + d * sliceSize` instead of `depthSlice(d)`. Pre-allocate reusable scratch `TensorStorage` buffers outside loops.
+7. **No Tensor Self-Assignment**: Never write `self.gamma = self.gamma - gradients` or similar patterns using Tensor arithmetic operators. The operators build autograd graphs that reference the old value, creating a reference cycle when assigned back to the same property. Instead, use `TensorStorage`-level arithmetic which has no autograd: `gamma = Tensor(storage: gamma.storage - gradients.storage, size: gamma.size)`. This applies to `apply(gradients:)` and any method that updates layer parameters in-place.
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,6 +353,7 @@ print(grads.input.count, grads.weights.count, grads.biases.count)
 8. **Gradient/weights layout mismatch**: Layers with multiple params (e.g. gamma, beta) must return gradients in the same order as `weights`. InstanceNormalize and LayerNormalize use `beta | gamma`; gradients must match or Adam weight decay corrupts training. See `InstanceNormalize.swift` and `AGENT_REFERENCE.md`.
 9. **Using `Tensor.Value` arithmetic in hot paths**: Prefer `NumSwiftFlat` pointer APIs to avoid intermediate array allocations. See "Pointer-Based Arithmetic" section.
 10. **Shared-memory bugs with optimizer state**: When returning optimizer state (e.g., SGD velocity) as a Tensor, use `TensorStorage.forceCopy()` to avoid the tensor mutating optimizer internals.
+11. **Tensor self-assignment creates reference cycles**: Tensor arithmetic operators (`+`, `-`, `*`, `/`) build autograd computation graphs. Writing `gamma = gamma - gradients` creates a reference cycle because the result's graph holds a reference to the old `gamma`, which is now the same variable as the new `gamma`. Instead, construct a fresh Tensor from the result's storage: `gamma = Tensor(storage: (gamma - gradients).storage, size: gamma.size)`. Alternatively, perform the arithmetic at the `TensorStorage` level (which has no autograd): `gamma = Tensor(storage: gamma.storage - gradients.storage, size: gamma.size)`. This applies anywhere a Tensor property is updated via arithmetic that references itself.
 
 ## Performance & Memory Profiling
 

--- a/Sources/Neuron/Layers/Add.swift
+++ b/Sources/Neuron/Layers/Add.swift
@@ -22,11 +22,13 @@ public final class Add: ArithmeticLayer {
   public init(inputSize: TensorSize = TensorSize(array: []),
               initializer: InitializerType = .heNormal,
               linkId: String = UUID().uuidString,
+              inverse: Bool = false,
               linkTo: String) {
     super.init(inputSize: inputSize,
                initializer: initializer,
                biasEnabled: false,
                encodingType: .add,
+               inverse: inverse,
                linkId: linkId,
                linkTo: linkTo)
   }

--- a/Sources/Neuron/Layers/BatchNormalize.swift
+++ b/Sources/Neuron/Layers/BatchNormalize.swift
@@ -25,14 +25,14 @@ import NumSwift
 ///
 /// Backpropagation uses the frozen-BN gradient `dx = dy × γ / σ`.
 public final class BatchNormalize: BaseThreadBatchingLayer {
-  /// Learnable scale parameters, one per channel.
-  public var gamma: [Tensor.Scalar] = []
-  /// Learnable shift parameters, one per channel.
-  public var beta: [Tensor.Scalar] = []
-  /// Per-channel moving mean for inference.
-  public var movingMean: [Tensor.Scalar] = []
-  /// Per-channel moving variance for inference.
-  public var movingVariance: [Tensor.Scalar] = []
+  /// Learnable scale parameters, one per channel. Shape: `(1, 1, depth)`.
+  public var gamma: Tensor = .init()
+  /// Learnable shift parameters, one per channel. Shape: `(1, 1, depth)`.
+  public var beta: Tensor = .init()
+  /// Per-channel moving mean for inference. Shape: `(1, 1, depth)`.
+  public var movingMean: Tensor = .init()
+  /// Per-channel moving variance for inference. Shape: `(1, 1, depth)`.
+  public var movingVariance: Tensor = .init()
 
   /// Momentum for exponential moving average of inference statistics.
   public let momentum: Tensor.Scalar
@@ -43,10 +43,10 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
   /// Setting this property has no effect.
   public override var weights: Tensor {
     get {
-      var combined = beta
-      combined.append(contentsOf: gamma)
-      combined.append(contentsOf: movingMean)
-      combined.append(contentsOf: movingVariance)
+      var combined = beta.storage.toArray()
+      combined.append(contentsOf: gamma.storage.toArray())
+      combined.append(contentsOf: movingMean.storage.toArray())
+      combined.append(contentsOf: movingVariance.storage.toArray())
       return Tensor(combined)
     }
     set {}
@@ -93,10 +93,10 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
               movingVariance: [Tensor.Scalar] = [],
               inputSize: TensorSize? = nil,
               linkId: String = UUID().uuidString) {
-    self.gamma = gamma
-    self.beta = beta
-    self.movingMean = movingMean
-    self.movingVariance = movingVariance
+    self.gamma = Self.perChannelTensor(from: gamma)
+    self.beta = Self.perChannelTensor(from: beta)
+    self.movingMean = Self.perChannelTensor(from: movingMean)
+    self.movingVariance = Self.perChannelTensor(from: movingVariance)
     self.momentum = momentum
 
     super.init(inputSize: inputSize,
@@ -159,11 +159,11 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)
-    try container.encode(beta, forKey: .beta)
-    try container.encode(gamma, forKey: .gamma)
+    try container.encode(beta.storage.toArray(), forKey: .beta)
+    try container.encode(gamma.storage.toArray(), forKey: .gamma)
     try container.encode(momentum, forKey: .momentum)
-    try container.encode(movingMean, forKey: .movingMean)
-    try container.encode(movingVariance, forKey: .movingVariance)
+    try container.encode(movingMean.storage.toArray(), forKey: .movingMean)
+    try container.encode(movingVariance.storage.toArray(), forKey: .movingVariance)
     try container.encode(linkId, forKey: .linkId)
   }
 
@@ -175,7 +175,7 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
     let sliceSize = inputSize.rows * inputSize.columns
     updateLock.with {
       for c in 0..<tensor.size.depth {
-        let ptr = tensor.storage.pointer + c * sliceSize
+        let ptr = tensor.depthPointer(c)
         channelSums[c] += NumSwiftFlat.sum(ptr, count: sliceSize)
         NumSwiftFlat.mul(ptr, ptr, result: scratchBuffer.pointer, count: sliceSize)
         channelSumSqs[c] += NumSwiftFlat.sum(scratchBuffer.pointer, count: sliceSize)
@@ -226,17 +226,16 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
     super.apply(gradients: gradients, learningRate: learningRate)
 
     let N = Tensor.Scalar(max(sampleCount, 1))
-    let avgDGamma = dGamma / N
-    let avgDBeta = dBeta / N
+    let avgDGammaT = Self.perChannelTensor(from: dGamma) / N
+    let avgDBetaT = Self.perChannelTensor(from: dBeta) / N
 
-    gamma = gamma - (avgDGamma * learningRate)
-    beta = beta - (avgDBeta * learningRate)
+    gamma = gamma.copy() - avgDGammaT * learningRate
+    beta = beta.copy() - avgDBetaT * learningRate
 
-    // Update moving stats from cached batch statistics
-    for c in 0..<inputSize.depth {
-      movingMean[c] = momentum * movingMean[c] + (1 - momentum) * batchMeans[c]
-      movingVariance[c] = momentum * movingVariance[c] + (1 - momentum) * batchVariances[c]
-    }
+    let batchMeansT = Self.perChannelTensor(from: batchMeans)
+    let batchVariancesT = Self.perChannelTensor(from: batchVariances)
+    movingMean = movingMean * momentum + batchMeansT * (1 - momentum)
+    movingVariance = movingVariance * momentum + batchVariancesT * (1 - momentum)
 
     resetDeltas()
     resetChannelAccumulators()
@@ -260,10 +259,11 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
 
   private func setupTrainables() {
     let depth = inputSize.depth
-    if gamma.isEmpty { gamma = [Tensor.Scalar](repeating: 1, count: depth) }
-    if beta.isEmpty { beta = [Tensor.Scalar](repeating: 0, count: depth) }
-    if movingMean.isEmpty { movingMean = [Tensor.Scalar](repeating: 0, count: depth) }
-    if movingVariance.isEmpty { movingVariance = [Tensor.Scalar](repeating: 1, count: depth) }
+    let pcSize = TensorSize(rows: 1, columns: 1, depth: depth)
+    if gamma.isEmpty { gamma = Tensor(storage: TensorStorage.create(repeating: 1, count: depth), size: pcSize) }
+    if beta.isEmpty { beta = Tensor(storage: TensorStorage.create(count: depth), size: pcSize) }
+    if movingMean.isEmpty { movingMean = Tensor(storage: TensorStorage.create(count: depth), size: pcSize) }
+    if movingVariance.isEmpty { movingVariance = Tensor(storage: TensorStorage.create(repeating: 1, count: depth), size: pcSize) }
     if batchMeans.count != depth { batchMeans = [Tensor.Scalar](repeating: 0, count: depth) }
     if batchVariances.count != depth { batchVariances = [Tensor.Scalar](repeating: 0, count: depth) }
   }
@@ -286,11 +286,14 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
     let depth = inputs.size.depth
     let sliceSize = inputSize.rows * inputSize.columns
 
-    var means = [Tensor.Scalar](repeating: 0, count: depth)
-    var stds  = [Tensor.Scalar](repeating: 0, count: depth)
+    let meanT: Tensor
+    let stdT: Tensor
+    var stds = [Tensor.Scalar](repeating: 0, count: depth)
 
-    for c in 0..<depth {
-      if isTraining {
+    if isTraining {
+      var means = [Tensor.Scalar](repeating: 0, count: depth)
+
+      for c in 0..<depth {
         let M = Tensor.Scalar(max(sampleCount * sliceSize, 1))
         let mean_c = channelSums[c] / M
         let var_c = max(channelSumSqs[c] / M - mean_c * mean_c, 0)
@@ -298,20 +301,18 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
         stds[c] = Tensor.Scalar.sqrt(var_c + e)
         batchMeans[c] = mean_c
         batchVariances[c] = var_c
-      } else {
-        means[c] = movingMean[c]
-        stds[c] = Tensor.Scalar.sqrt(movingVariance[c] + e)
       }
+
+      meanT = Self.perChannelTensor(from: means)
+      stdT = Self.perChannelTensor(from: stds)
+    } else {
+      meanT = movingMean
+      stdT = movingVariance.sqrt(adding: e)
+      for c in 0..<depth { stds[c] = stdT.storage[c] }
     }
 
-    let pcSize = TensorSize(rows: 1, columns: 1, depth: depth)
-    let meanT  = Tensor(storage: TensorStorage.create(from: means), size: pcSize)
-    let stdT   = Tensor(storage: TensorStorage.create(from: stds), size: pcSize)
-    let gammaT = Tensor(storage: TensorStorage.create(from: gamma), size: pcSize)
-    let betaT  = Tensor(storage: TensorStorage.create(from: beta), size: pcSize)
-
     let normalized = (inputs - meanT) / stdT
-    let output = normalized * gammaT + betaT
+    let output = normalized * gamma + beta
 
     return (output.storage, Normalization(normalized: normalized, stds: stds))
   }
@@ -331,11 +332,16 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
       }
     }
 
-    var scales = [Tensor.Scalar](repeating: 0, count: depth)
-    for c in 0..<depth { scales[c] = gamma[c] / normalization.stds[c] }
-    let scaleT = Tensor(storage: TensorStorage.create(from: scales),
-                        size: TensorSize(rows: 1, columns: 1, depth: depth))
+    let stdsT = Self.perChannelTensor(from: normalization.stds)
+    let scaleT = gamma / stdsT
     return gradient * scaleT
+  }
+
+  private static func perChannelTensor(from scalars: [Tensor.Scalar]) -> Tensor {
+    let depth = scalars.count
+    guard depth > 0 else { return Tensor() }
+    return Tensor(storage: TensorStorage.create(from: scalars),
+                  size: TensorSize(rows: 1, columns: 1, depth: depth))
   }
 
   // MARK: - Codable Helpers

--- a/Sources/Neuron/Layers/BatchNormalize.swift
+++ b/Sources/Neuron/Layers/BatchNormalize.swift
@@ -72,8 +72,8 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
   private var batchVariances: [Tensor.Scalar] = []
 
   private struct Normalization {
-    let normalized: TensorStorage
-    let std: Tensor.Scalar
+    let normalized: Tensor
+    let stds: [Tensor.Scalar]
   }
 
   /// Creates a batch-normalization layer.
@@ -204,12 +204,12 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
     }
 
     let forward = normalize(inputs: tensor, context: context)
-    let normalizations = forward.normalized
+    let normalization = forward.normalized
 
     let tensorContext = TensorContext { inputs, gradient, wrt in
       let backward = self.backward(inputs: inputs,
                                    gradient: gradient,
-                                   normalizations: normalizations)
+                                   normalization: normalization)
       backward.label = "BatchNorm"
       return (backward, Tensor(), Tensor())
     }
@@ -282,74 +282,60 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
   }
 
   private func normalize(inputs: Tensor,
-                         context: NetworkContext) -> (output: TensorStorage, normalized: [Normalization]) {
+                         context: NetworkContext) -> (output: TensorStorage, normalized: Normalization) {
     let depth = inputs.size.depth
     let sliceSize = inputSize.rows * inputSize.columns
-    let outStorage = TensorStorage.create(count: inputs.storage.count)
-    var normalizedInputs: [Normalization] = []
+
+    var means = [Tensor.Scalar](repeating: 0, count: depth)
+    var stds  = [Tensor.Scalar](repeating: 0, count: depth)
 
     for c in 0..<depth {
-      let inputPtr = inputs.storage.pointer + c * sliceSize
-      let outPtr   = outStorage.pointer + c * sliceSize
-
-      let mean_c: Tensor.Scalar
-      let std_c: Tensor.Scalar
-
       if isTraining {
         let M = Tensor.Scalar(max(sampleCount * sliceSize, 1))
-        mean_c = channelSums[c] / M
+        let mean_c = channelSums[c] / M
         let var_c = max(channelSumSqs[c] / M - mean_c * mean_c, 0)
-        std_c = Tensor.Scalar.sqrt(var_c + e)
-
+        means[c] = mean_c
+        stds[c] = Tensor.Scalar.sqrt(var_c + e)
         batchMeans[c] = mean_c
         batchVariances[c] = var_c
       } else {
-        mean_c = movingMean[c]
-        std_c = Tensor.Scalar.sqrt(movingVariance[c] + e)
+        means[c] = movingMean[c]
+        stds[c] = Tensor.Scalar.sqrt(movingVariance[c] + e)
       }
-
-      // normalized = (input - mean_c) / std_c
-      let normStorage = TensorStorage.create(count: sliceSize)
-      NumSwiftFlat.sub(inputPtr, scalar: mean_c, result: normStorage.pointer, count: sliceSize)
-      NumSwiftFlat.div(normStorage.pointer, scalar: std_c, result: normStorage.pointer, count: sliceSize)
-
-      normalizedInputs.append(Normalization(normalized: normStorage, std: std_c))
-
-      // output = gamma_c * normalized + beta_c
-      NumSwiftFlat.mul(normStorage.pointer, scalar: gamma[c], result: outPtr, count: sliceSize)
-      NumSwiftFlat.add(outPtr, scalar: beta[c], result: outPtr, count: sliceSize)
     }
 
-    return (outStorage, normalizedInputs)
+    let pcSize = TensorSize(rows: 1, columns: 1, depth: depth)
+    let meanT  = Tensor(storage: TensorStorage.create(from: means), size: pcSize)
+    let stdT   = Tensor(storage: TensorStorage.create(from: stds), size: pcSize)
+    let gammaT = Tensor(storage: TensorStorage.create(from: gamma), size: pcSize)
+    let betaT  = Tensor(storage: TensorStorage.create(from: beta), size: pcSize)
+
+    let normalized = (inputs - meanT) / stdT
+    let output = normalized * gammaT + betaT
+
+    return (output.storage, Normalization(normalized: normalized, stds: stds))
   }
 
   private func backward(inputs: Tensor,
                         gradient: Tensor,
-                        normalizations: [Normalization]) -> Tensor {
+                        normalization: Normalization) -> Tensor {
     let depth = inputs.size.depth
     let sliceSize = inputSize.rows * inputSize.columns
-    let outStorage = TensorStorage.create(count: inputs.storage.count)
-    let tmpA = TensorStorage.create(count: sliceSize)
+
+    let gradTimesNorm = gradient * normalization.normalized
 
     for c in 0..<depth {
-      let gradPtr = gradient.storage.pointer + c * sliceSize
-      let outPtr  = outStorage.pointer + c * sliceSize
-
-      let normStorage = normalizations[c].normalized
-      let std_c = normalizations[c].std
-
       updateLock.with {
-        NumSwiftFlat.mul(gradPtr, normStorage.pointer, result: tmpA.pointer, count: sliceSize)
-        dGamma[c] += NumSwiftFlat.sum(tmpA.pointer, count: sliceSize)
-        dBeta[c] += NumSwiftFlat.sum(gradPtr, count: sliceSize)
+        dGamma[c] += NumSwiftFlat.sum(gradTimesNorm.depthPointer(c), count: sliceSize)
+        dBeta[c] += NumSwiftFlat.sum(gradient.depthPointer(c), count: sliceSize)
       }
-
-      // Frozen BN gradient: dx = dy * gamma_c / std_c
-      let scale = gamma[c] / std_c
-      NumSwiftFlat.mul(gradPtr, scalar: scale, result: outPtr, count: sliceSize)
     }
 
-    return Tensor(storage: outStorage, size: inputs.size)
+    var scales = [Tensor.Scalar](repeating: 0, count: depth)
+    for c in 0..<depth { scales[c] = gamma[c] / normalization.stds[c] }
+    let scaleT = Tensor(storage: TensorStorage.create(from: scales),
+                        size: TensorSize(rows: 1, columns: 1, depth: depth))
+    return gradient * scaleT
   }
 
   // MARK: - Codable Helpers

--- a/Sources/Neuron/Layers/BatchNormalize.swift
+++ b/Sources/Neuron/Layers/BatchNormalize.swift
@@ -234,8 +234,8 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
 
     let batchMeansT = Self.perChannelTensor(from: batchMeans)
     let batchVariancesT = Self.perChannelTensor(from: batchVariances)
-    movingMean = movingMean * momentum + batchMeansT * (1 - momentum)
-    movingVariance = movingVariance * momentum + batchVariancesT * (1 - momentum)
+    movingMean = movingMean.copy() * momentum + batchMeansT * (1 - momentum)
+    movingVariance = movingVariance.copy() * momentum + batchVariancesT * (1 - momentum)
 
     resetDeltas()
     resetChannelAccumulators()

--- a/Sources/Neuron/Layers/Conv2d.swift
+++ b/Sources/Neuron/Layers/Conv2d.swift
@@ -399,10 +399,12 @@ public class Conv2d: BaseConvolutionalLayer {
         }
       }
 
-      if biasEnabled {
-        let biasVal = biases.storage[f]
-        NumSwiftFlat.add(resultPtr, scalar: biasVal, result: resultPtr, count: outSliceSize)
-      }
+    }
+
+    if biasEnabled {
+      let biasT = Tensor(storage: biases.storage, size: TensorSize(rows: 1, columns: 1, depth: filterCount))
+      let result = Tensor(storage: resultStorage, size: outputSize) + biasT
+      return result.storage
     }
 
     return resultStorage

--- a/Sources/Neuron/Layers/DepthwiseConv2d.swift
+++ b/Sources/Neuron/Layers/DepthwiseConv2d.swift
@@ -451,11 +451,11 @@ public class DepthwiseConv2d: BaseConvolutionalLayer {
                          filterSize: self.filterSize,
                          inputSize: (self.inputSize.rows, self.inputSize.columns),
                          batchCount: 1)
+    }
 
-      if self.biasEnabled {
-        let bias = self.biases.storage[i]
-        NumSwiftFlat.add(destPtr, scalar: bias, result: destPtr, count: outSliceSize)
-      }
+    if biasEnabled {
+      let biasT = Tensor(storage: biases.storage, size: TensorSize(rows: 1, columns: 1, depth: outputSize.depth))
+      return Tensor(storage: resultStorage, size: outputSize) + biasT
     }
 
     return Tensor(storage: resultStorage, size: outputSize)

--- a/Sources/Neuron/Layers/Divide.swift
+++ b/Sources/Neuron/Layers/Divide.swift
@@ -46,10 +46,6 @@ public final class Divide: ArithmeticLayer {
   }
   
   override public func function(input: Tensor, other: Tensor) -> Tensor {
-    if inverse {
-      other / input
-    } else {
-      input / other
-    }
+    input / other
   }
 }

--- a/Sources/Neuron/Layers/InstanceNormalize.swift
+++ b/Sources/Neuron/Layers/InstanceNormalize.swift
@@ -98,10 +98,10 @@ public final class InstanceNormalize: BaseLayer {
   /// - Returns: Normalized tensor with layer-norm backpropagation context.
   public override func forward(tensor: Tensor, context: NetworkContext = .init()) -> Tensor {
     let tensotContext = TensorContext { inputs, gradient, wrt in
-      self.backwardFlat(inputs: inputs, gradient: gradient)
+      self.backward(inputs: inputs, gradient: gradient)
     }
 
-    let forwardStorage = normalizeFlat(inputs: tensor)
+    let forwardStorage = normalize(inputs: tensor)
     let out = Tensor(storage: forwardStorage, size: tensor.size, context: tensotContext)
     out.setGraph(tensor)
 
@@ -114,7 +114,7 @@ public final class InstanceNormalize: BaseLayer {
     setupTrainables()
   }
 
-  private func normalizeFlat(inputs: Tensor) -> TensorStorage {
+  private func normalize(inputs: Tensor) -> TensorStorage {
     let depth = inputs.size.depth
     let sliceSize = inputSize.rows * inputSize.columns
     let pcSize = TensorSize(rows: 1, columns: 1, depth: depth)
@@ -133,16 +133,16 @@ public final class InstanceNormalize: BaseLayer {
       stds[i] = Tensor.Scalar.sqrt(sumSq / Tensor.Scalar(sliceSize) + epsilon)
     }
 
-    let stdT   = Tensor(storage: TensorStorage.create(from: stds), size: pcSize)
+    let stdT = Tensor(storage: TensorStorage.create(from: stds), size: pcSize)
     let gammaT = Tensor(storage: gamma.storage, size: pcSize)
-    let betaT  = Tensor(storage: beta.storage, size: pcSize)
+    let betaT = Tensor(storage: beta.storage, size: pcSize)
 
     let normalized = centered / stdT
     let output = normalized * gammaT + betaT
     return output.storage
   }
   
-  private func backwardFlat(inputs: Tensor, gradient: Tensor) -> (input: Tensor, weight: Tensor, bias: Tensor) {
+  private func backward(inputs: Tensor, gradient: Tensor) -> (input: Tensor, weight: Tensor, bias: Tensor) {
     let depth = inputs.size.depth
     let sliceSize = inputSize.rows * inputSize.columns
     let N = Tensor.Scalar(sliceSize)
@@ -154,7 +154,7 @@ public final class InstanceNormalize: BaseLayer {
     for i in 0..<depth {
       means[i] = NumSwiftFlat.mean(inputs.depthPointer(i), count: sliceSize)
     }
-
+    
     let meanT = Tensor(storage: TensorStorage.create(from: means), size: pcSize)
     let centered = inputs - meanT
 
@@ -168,16 +168,16 @@ public final class InstanceNormalize: BaseLayer {
 
     let xNormTimesGrad = xNorm * gradient
     var dGammas = [Tensor.Scalar](repeating: 0, count: depth)
-    var dBetas  = [Tensor.Scalar](repeating: 0, count: depth)
+    var dBetas = [Tensor.Scalar](repeating: 0, count: depth)
     for i in 0..<depth {
       dBetas[i] = NumSwiftFlat.sum(gradient.depthPointer(i), count: sliceSize)
       dGammas[i] = NumSwiftFlat.sum(xNormTimesGrad.depthPointer(i), count: sliceSize)
     }
 
-    let gammaT   = Tensor(storage: gamma.storage, size: pcSize)
+    let gammaT = Tensor(storage: gamma.storage, size: pcSize)
     let invNStdT = gammaT / (Tensor(N) * stdT)
-    let dBetaT   = Tensor(storage: TensorStorage.create(from: dBetas), size: pcSize)
-    let dGammaT  = Tensor(storage: TensorStorage.create(from: dGammas), size: pcSize)
+    let dBetaT = Tensor(storage: TensorStorage.create(from: dBetas), size: pcSize)
+    let dGammaT = Tensor(storage: TensorStorage.create(from: dGammas), size: pcSize)
 
     let dInput = (gradient * N - dBetaT - xNorm * dGammaT) * invNStdT
 
@@ -199,8 +199,8 @@ public final class InstanceNormalize: BaseLayer {
     let betaWeights = gradients.weights.depthSliceTensor(0)
     let gammaWeights = gradients.weights.depthSliceTensor(1)
 
-    gamma = gamma - gammaWeights
-    beta = beta - betaWeights
+    gamma = gamma.copy() - gammaWeights
+    beta = beta.copy() - betaWeights
   }
   
   private func setupTrainables() {

--- a/Sources/Neuron/Layers/InstanceNormalize.swift
+++ b/Sources/Neuron/Layers/InstanceNormalize.swift
@@ -117,34 +117,31 @@ public final class InstanceNormalize: BaseLayer {
   private func normalizeFlat(inputs: Tensor) -> TensorStorage {
     let depth = inputs.size.depth
     let sliceSize = inputSize.rows * inputSize.columns
-    let outStorage = TensorStorage.create(count: inputs.storage.count)
+    let pcSize = TensorSize(rows: 1, columns: 1, depth: depth)
 
-    // Scratch buffer for centered values (reused each depth slice)
+    var means = [Tensor.Scalar](repeating: 0, count: depth)
+    var stds  = [Tensor.Scalar](repeating: 0, count: depth)
+
     let centeredBuf = TensorStorage.create(count: sliceSize)
 
     for i in 0..<depth {
-      let gammaVal = gamma.storage[i]
-      let betaVal  = beta.storage[i]
-      let inPtr    = inputs.storage.pointer + i * sliceSize
-      let outPtr   = outStorage.pointer + i * sliceSize
-
-      // mean = sum(slice) / sliceSize
+      let inPtr = inputs.storage.pointer + i * sliceSize
       let mean = NumSwiftFlat.mean(inPtr, count: sliceSize)
+      means[i] = mean
 
-      // centered = slice - mean
       NumSwiftFlat.sub(inPtr, scalar: mean, result: centeredBuf.pointer, count: sliceSize)
-
-      // variance = sumOfSquares(centered) / sliceSize
       let sumSq = NumSwiftFlat.sumOfSquares(centeredBuf.pointer, count: sliceSize)
-      let std = Tensor.Scalar.sqrt(sumSq / Tensor.Scalar(sliceSize) + epsilon)
-
-      // normalized = centered / std, then scale: normalized * gamma[i] + beta[i]
-      NumSwiftFlat.div(centeredBuf.pointer, scalar: std, result: outPtr, count: sliceSize)
-      NumSwiftFlat.mul(outPtr, scalar: gammaVal, result: outPtr, count: sliceSize)
-      NumSwiftFlat.add(outPtr, scalar: betaVal, result: outPtr, count: sliceSize)
+      stds[i] = Tensor.Scalar.sqrt(sumSq / Tensor.Scalar(sliceSize) + epsilon)
     }
 
-    return outStorage
+    let meanT  = Tensor(storage: TensorStorage.create(from: means), size: pcSize)
+    let stdT   = Tensor(storage: TensorStorage.create(from: stds), size: pcSize)
+    let gammaT = Tensor(storage: gamma.storage, size: pcSize)
+    let betaT  = Tensor(storage: beta.storage, size: pcSize)
+
+    let normalized = (inputs - meanT) / stdT
+    let output = normalized * gammaT + betaT
+    return output.storage
   }
   
   private func backwardFlat(inputs: Tensor, gradient: Tensor) -> (input: Tensor, weight: Tensor, bias: Tensor) {

--- a/Sources/Neuron/Layers/InstanceNormalize.swift
+++ b/Sources/Neuron/Layers/InstanceNormalize.swift
@@ -120,26 +120,24 @@ public final class InstanceNormalize: BaseLayer {
     let pcSize = TensorSize(rows: 1, columns: 1, depth: depth)
 
     var means = [Tensor.Scalar](repeating: 0, count: depth)
-    var stds  = [Tensor.Scalar](repeating: 0, count: depth)
-
-    let centeredBuf = TensorStorage.create(count: sliceSize)
-
     for i in 0..<depth {
-      let inPtr = inputs.storage.pointer + i * sliceSize
-      let mean = NumSwiftFlat.mean(inPtr, count: sliceSize)
-      means[i] = mean
+      means[i] = NumSwiftFlat.mean(inputs.depthPointer(i), count: sliceSize)
+    }
 
-      NumSwiftFlat.sub(inPtr, scalar: mean, result: centeredBuf.pointer, count: sliceSize)
-      let sumSq = NumSwiftFlat.sumOfSquares(centeredBuf.pointer, count: sliceSize)
+    let meanT = Tensor(storage: TensorStorage.create(from: means), size: pcSize)
+    let centered = inputs - meanT
+
+    var stds = [Tensor.Scalar](repeating: 0, count: depth)
+    for i in 0..<depth {
+      let sumSq = NumSwiftFlat.sumOfSquares(centered.depthPointer(i), count: sliceSize)
       stds[i] = Tensor.Scalar.sqrt(sumSq / Tensor.Scalar(sliceSize) + epsilon)
     }
 
-    let meanT  = Tensor(storage: TensorStorage.create(from: means), size: pcSize)
     let stdT   = Tensor(storage: TensorStorage.create(from: stds), size: pcSize)
     let gammaT = Tensor(storage: gamma.storage, size: pcSize)
     let betaT  = Tensor(storage: beta.storage, size: pcSize)
 
-    let normalized = (inputs - meanT) / stdT
+    let normalized = centered / stdT
     let output = normalized * gammaT + betaT
     return output.storage
   }

--- a/Sources/Neuron/Layers/InstanceNormalize.swift
+++ b/Sources/Neuron/Layers/InstanceNormalize.swift
@@ -148,60 +148,45 @@ public final class InstanceNormalize: BaseLayer {
     let depth = inputs.size.depth
     let sliceSize = inputSize.rows * inputSize.columns
     let N = Tensor.Scalar(sliceSize)
+    let pcSize = TensorSize(rows: 1, columns: 1, depth: depth)
 
-    let dInputResult = TensorStorage.create(count: sliceSize * depth)
-    let dGammaResult = TensorStorage.create(count: depth)
-    let dBetaResult  = TensorStorage.create(count: depth)
-
-    // Scratch buffers reused each depth slice
-    let xNorm = TensorStorage.create(count: sliceSize)  // (input - mean) / std
-    let tmp   = TensorStorage.create(count: sliceSize)  // general scratch
+    var means = [Tensor.Scalar](repeating: 0, count: depth)
+    var stds  = [Tensor.Scalar](repeating: 0, count: depth)
 
     for i in 0..<depth {
-      let gammaVal = gamma.storage[i]
-      let inPtr    = inputs.storage.pointer + i * sliceSize
-      let gradPtr  = gradient.storage.pointer + i * sliceSize
-      let outPtr   = dInputResult.pointer + i * sliceSize
-
-      // mean, variance, std  (matching forward pass)
-      let mean = NumSwiftFlat.mean(inPtr, count: sliceSize)
-      NumSwiftFlat.sub(inPtr, scalar: mean, result: xNorm.pointer, count: sliceSize)
-      let sumSq = NumSwiftFlat.sumOfSquares(xNorm.pointer, count: sliceSize)
-      let std = Tensor.Scalar.sqrt(sumSq / N + epsilon)
-
-      // x_norm = (input - mean) / std  (reuse xNorm buffer)
-      NumSwiftFlat.div(xNorm.pointer, scalar: std, result: xNorm.pointer, count: sliceSize)
-
-      // dL_dbeta = sum(grad)
-      let dL_dbeta = NumSwiftFlat.sum(gradPtr, count: sliceSize)
-
-      // dL_dgamma = sum(x_norm * grad)
-      NumSwiftFlat.mul(xNorm.pointer, gradPtr, result: tmp.pointer, count: sliceSize)
-      let dL_dgamma = NumSwiftFlat.sum(tmp.pointer, count: sliceSize)
-
-      // invNStd = gamma[i] / (N * std)
-      let invNStd = gammaVal / (N * std)
-
-      // dl_dx = invNStd * (N * grad - dL_dbeta - x_norm * dL_dgamma)
-      // tmp = N * grad - dL_dbeta
-      NumSwiftFlat.mul(gradPtr, scalar: N, result: tmp.pointer, count: sliceSize)
-      NumSwiftFlat.sub(tmp.pointer, scalar: dL_dbeta, result: tmp.pointer, count: sliceSize)
-      // xNorm = x_norm * dL_dgamma  (reuse xNorm)
-      NumSwiftFlat.mul(xNorm.pointer, scalar: dL_dgamma, result: xNorm.pointer, count: sliceSize)
-      // tmp = tmp - xNorm
-      NumSwiftFlat.sub(tmp.pointer, xNorm.pointer, result: tmp.pointer, count: sliceSize)
-      // outPtr = invNStd * tmp
-      NumSwiftFlat.mul(tmp.pointer, scalar: invNStd, result: outPtr, count: sliceSize)
-
-      dGammaResult[i] = dL_dgamma
-      dBetaResult[i]  = dL_dbeta
+      means[i] = NumSwiftFlat.mean(inputs.depthPointer(i), count: sliceSize)
     }
 
-    let dGammaTensor = Tensor(storage: dGammaResult, size: TensorSize(rows: 1, columns: depth, depth: 1))
-    let dBetaTensor  = Tensor(storage: dBetaResult,  size: TensorSize(rows: 1, columns: depth, depth: 1))
+    let meanT = Tensor(storage: TensorStorage.create(from: means), size: pcSize)
+    let centered = inputs - meanT
 
-    // Return dBeta.concat(dGamma) to match weights layout (beta.concat(gamma)) for correct optimizer indexing
-    return (Tensor(storage: dInputResult, size: inputs.size),
+    for i in 0..<depth {
+      let sumSq = NumSwiftFlat.sumOfSquares(centered.depthPointer(i), count: sliceSize)
+      stds[i] = Tensor.Scalar.sqrt(sumSq / N + epsilon)
+    }
+
+    let stdT = Tensor(storage: TensorStorage.create(from: stds), size: pcSize)
+    let xNorm = centered / stdT
+
+    let xNormTimesGrad = xNorm * gradient
+    var dGammas = [Tensor.Scalar](repeating: 0, count: depth)
+    var dBetas  = [Tensor.Scalar](repeating: 0, count: depth)
+    for i in 0..<depth {
+      dBetas[i] = NumSwiftFlat.sum(gradient.depthPointer(i), count: sliceSize)
+      dGammas[i] = NumSwiftFlat.sum(xNormTimesGrad.depthPointer(i), count: sliceSize)
+    }
+
+    let gammaT   = Tensor(storage: gamma.storage, size: pcSize)
+    let invNStdT = gammaT / (Tensor(N) * stdT)
+    let dBetaT   = Tensor(storage: TensorStorage.create(from: dBetas), size: pcSize)
+    let dGammaT  = Tensor(storage: TensorStorage.create(from: dGammas), size: pcSize)
+
+    let dInput = (gradient * N - dBetaT - xNorm * dGammaT) * invNStdT
+
+    let dGammaTensor = Tensor(storage: TensorStorage.create(from: dGammas), size: TensorSize(rows: 1, columns: depth, depth: 1))
+    let dBetaTensor  = Tensor(storage: TensorStorage.create(from: dBetas), size: TensorSize(rows: 1, columns: depth, depth: 1))
+
+    return (dInput,
             dBetaTensor.concat(dGammaTensor, axis: 2),
             Tensor())
   }

--- a/Sources/Neuron/Layers/Layer.swift
+++ b/Sources/Neuron/Layers/Layer.swift
@@ -171,7 +171,9 @@ open class ArithmeticLayer: BaseLayer {
     super.onInputSizeSet()
     /// do something when the input size is set when calling `compile` on `Sequential`
     /// like setting the output size or initializing the weights
-    outputSize = inputSize
+    if outputSize.isEmpty {
+      outputSize = inputSize
+    }
   }
   
   required convenience public init(from decoder: Decoder) throws {
@@ -197,13 +199,16 @@ open class ArithmeticLayer: BaseLayer {
   ///   - context: The network context in which the forward pass is executed.
   /// - Returns: The output tensor produced by applying the layer's function to the input and linked tensors.
   public override func forward(tensor: Tensor, context: NetworkContext) -> Tensor {
-    
     guard let other = lookupInput(input: tensor) else {
       assertionFailure("could not find reference input tensor in graph")
       return Tensor()
     }
     
-    let out = function(input: tensor, other: other)
+    let out = if inverse {
+      function(input: other, other: tensor)
+    } else {
+      function(input: tensor, other: other)
+    }
     
     return super.forward(tensor: out, context: context)
   }

--- a/Sources/Neuron/Layers/Multiply.swift
+++ b/Sources/Neuron/Layers/Multiply.swift
@@ -15,11 +15,13 @@ public final class Multiply: ArithmeticLayer {
   public init(inputSize: TensorSize = TensorSize(array: []),
               initializer: InitializerType = .heNormal,
               linkId: String = UUID().uuidString,
+              inverse: Bool = false,
               linkTo: String) {
     super.init(inputSize: inputSize,
                initializer: initializer,
                biasEnabled: false,
                encodingType: .multiply,
+               inverse: inverse,
                linkId: linkId,
                linkTo: linkTo)
   }

--- a/Sources/Neuron/Layers/RexNet.swift
+++ b/Sources/Neuron/Layers/RexNet.swift
@@ -86,17 +86,23 @@ public final class RexNet: BaseLayerGroup {
       
       // Step 3: Squeeze-and-Excite (optional)
       if squeeze > 0 {
+        let channelsBeforeSE = expandRatio > 1
+            ? Int(inputSize.depth.asTensorScalar * expandRatio)
+            : inputSize.depth
+        
         let squeezeLayers: [Layer] = [
           GlobalAvgPool(),
-          Dense(Int(inputSize.depth) / squeeze,
+          Dense(channelsBeforeSE / squeeze,
                 initializer: initializer,
                 biasEnabled: true),
           ReLu(),
-          Dense(inputSize.depth,
+          Dense(channelsBeforeSE,
                 initializer: initializer,
                 biasEnabled: true),
           Sigmoid(),
-          Multiply(linkTo: "squeeze")
+          Reshape(to: .init(rows: 1, columns: 1, depth: channelsBeforeSE)),
+          Multiply(inverse: true,
+                   linkTo: "squeeze")
         ]
         
         layers.append(contentsOf: squeezeLayers)

--- a/Sources/Neuron/Layers/Subtract.swift
+++ b/Sources/Neuron/Layers/Subtract.swift
@@ -43,10 +43,6 @@ public final class Subtract: ArithmeticLayer {
   }
   
   override public func function(input: Tensor, other: Tensor) -> Tensor {
-    if inverse {
-      other - input
-    } else {
-      input - other
-    }
+    input - other
   }
 }

--- a/Sources/Neuron/Layers/TransConv2d.swift
+++ b/Sources/Neuron/Layers/TransConv2d.swift
@@ -280,15 +280,13 @@ public final class TransConv2d: Conv2d {
       }
     }
 
-    // Apply bias and copy accumulated results into resultStorage
-    for f in 0..<filterCount {
-      let accumPtr  = accumBuf.pointer + f * outSliceSize
-      let resultPtr = resultStorage.pointer + f * outSliceSize
-      if biasEnabled {
-        NumSwiftFlat.add(accumPtr, scalar: biases.storage[f], result: resultPtr, count: outSliceSize)
-      } else {
-        resultPtr.update(from: accumPtr, count: outSliceSize)
-      }
+    // Copy accumulated results into resultStorage
+    resultStorage.pointer.update(from: accumBuf.pointer, count: outSliceSize * filterCount)
+
+    if biasEnabled {
+      let biasT = Tensor(storage: biases.storage, size: TensorSize(rows: 1, columns: 1, depth: filterCount))
+      let result = Tensor(storage: resultStorage, size: outputSize) + biasT
+      return result.storage
     }
 
     return resultStorage

--- a/Sources/Neuron/Tensor/TensorMath.swift
+++ b/Sources/Neuron/Tensor/TensorMath.swift
@@ -142,6 +142,48 @@ public extension Tensor {
 
   private enum _BroadcastOp { case add, sub, mul, div }
 
+  /// Per-channel broadcasting fast path for (W,H,D) op (1,1,D).
+  /// Applies a per-depth scalar from `value` across each spatial slice of `self`.
+  private func _broadcastPerChannelFastPath(value: Tensor, op: _BroadcastOp) -> Tensor? {
+    let selfSize = size
+    let inputSize = value.size
+    guard inputSize.columns == 1,
+          inputSize.rows == 1,
+          inputSize.depth == selfSize.depth else { return nil }
+
+    let columns = selfSize.columns
+    let rows = selfSize.rows
+    let depth = selfSize.depth
+    let sliceSize = columns * rows
+    let totalCount = sliceSize * depth
+    guard totalCount > 0 else { return nil }
+
+    let resultStorage = TensorStorage.create(count: totalCount)
+    let selfPtr = storage.pointer
+    let inputPtr = value.storage.pointer
+    let resultPtr = resultStorage.pointer
+
+    for d in 0..<depth {
+      let offset = d * sliceSize
+      let scalar = inputPtr[d]
+      switch op {
+      case .add: NumSwiftFlat.add(selfPtr + offset, scalar: scalar, result: resultPtr + offset, count: sliceSize)
+      case .sub: NumSwiftFlat.sub(selfPtr + offset, scalar: scalar, result: resultPtr + offset, count: sliceSize)
+      case .mul: NumSwiftFlat.mul(selfPtr + offset, scalar: scalar, result: resultPtr + offset, count: sliceSize)
+      case .div: NumSwiftFlat.div(selfPtr + offset, scalar: scalar, result: resultPtr + offset, count: sliceSize)
+      }
+    }
+
+    let context: TensorContext
+    switch op {
+    case .add: context = addContext(value: value)
+    case .sub: context = subtractContext(value: value)
+    case .mul: context = multiplyContext(value: value)
+    case .div: context = divideContext(value: value)
+    }
+    return Tensor(storage: resultStorage, size: selfSize, context: context)
+  }
+
   /// Pointer-based fast path for *Along broadcasting. Returns result storage when applicable, nil to fall back.
   private func _broadcastAlongFastPath(axis: Int, value: Tensor, op: _BroadcastOp) -> Tensor? {
     let inputSize = value.size
@@ -923,17 +965,22 @@ public extension Tensor {
       return lhs.addAlong(axis: axis, value: rhs)
     }
     
+    if let new = lhs._broadcastPerChannelFastPath(value: rhs, op: .add) {
+      new.label = "addition"
+      if lhs.graphChain.contains(rhs.id) { new.setGraphSafe(lhs); new.setGraphSafe(rhs) }
+      else { new.setGraphSafe(rhs); new.setGraphSafe(lhs) }
+      return new
+    }
+    
     let result = lhs.storage + rhs.storage
     
     let new = Tensor(storage: result, size: lhs.size, context: lhs.addContext(value: rhs))
     new.label = "addition"
     
     if lhs.graphChain.contains(rhs.id) {
-      // non branched node
       new.setGraphSafe(lhs)
       new.setGraphSafe(rhs)
     } else {
-      // branched node
       new.setGraphSafe(rhs)
       new.setGraphSafe(lhs)
     }
@@ -948,17 +995,22 @@ public extension Tensor {
       return lhs.subtractAlong(axis: axis, value: rhs)
     }
     
+    if let new = lhs._broadcastPerChannelFastPath(value: rhs, op: .sub) {
+      new.label = "subtraction"
+      if lhs.graphChain.contains(rhs.id) { new.setGraphSafe(lhs); new.setGraphSafe(rhs) }
+      else { new.setGraphSafe(rhs); new.setGraphSafe(lhs) }
+      return new
+    }
+    
     let result = lhs.storage - rhs.storage
 
     let new = Tensor(storage: result, size: lhs.size, context: lhs.subtractContext(value: rhs))
     new.label = "subtraction"
 
     if lhs.graphChain.contains(rhs.id) {
-      // non branched node
       new.setGraphSafe(lhs)
       new.setGraphSafe(rhs)
     } else {
-      // branched node
       new.setGraphSafe(rhs)
       new.setGraphSafe(lhs)
     }
@@ -973,17 +1025,22 @@ public extension Tensor {
       return lhs.multiplyAlong(axis: axis, value: rhs)
     }
     
+    if let new = lhs._broadcastPerChannelFastPath(value: rhs, op: .mul) {
+      new.label = "multiplication"
+      if lhs.graphChain.contains(rhs.id) { new.setGraphSafe(lhs); new.setGraphSafe(rhs) }
+      else { new.setGraphSafe(rhs); new.setGraphSafe(lhs) }
+      return new
+    }
+    
     let result = lhs.storage * rhs.storage
 
     let new = Tensor(storage: result, size: lhs.size, context: lhs.multiplyContext(value: rhs))
     new.label = "multiplication"
 
     if lhs.graphChain.contains(rhs.id) {
-      // non branched node
       new.setGraphSafe(lhs)
       new.setGraphSafe(rhs)
     } else {
-      // branched node
       new.setGraphSafe(rhs)
       new.setGraphSafe(lhs)
     }
@@ -998,17 +1055,22 @@ public extension Tensor {
       return lhs.divideAlong(axis: axis, value: rhs)
     }
     
+    if let new = lhs._broadcastPerChannelFastPath(value: rhs, op: .div) {
+      new.label = "division"
+      if lhs.graphChain.contains(rhs.id) { new.setGraphSafe(lhs); new.setGraphSafe(rhs) }
+      else { new.setGraphSafe(rhs); new.setGraphSafe(lhs) }
+      return new
+    }
+    
     let result = lhs.storage / rhs.storage
 
     let new = Tensor(storage: result, size: lhs.size, context: lhs.divideContext(value: rhs))
     new.label = "division"
 
     if lhs.graphChain.contains(rhs.id) {
-      // non branched node
       new.setGraphSafe(lhs)
       new.setGraphSafe(rhs)
     } else {
-      // branched node
       new.setGraphSafe(rhs)
       new.setGraphSafe(lhs)
     }

--- a/Sources/Neuron/Tensor/TensorMath.swift
+++ b/Sources/Neuron/Tensor/TensorMath.swift
@@ -1009,11 +1009,13 @@ public extension Tensor {
   }
   
   func map(_ transform: (Tensor.Scalar) -> Tensor.Scalar) -> Tensor {
-    var result = Tensor.Value(repeating: 0, count: storage.count)
+    let result = TensorStorage.create(count: storage.count)
+    let srcPtr = storage.pointer
+    let dstPtr = result.pointer
     for i in 0..<storage.count {
-      result[i] = transform(storage[i])
+      dstPtr[i] = transform(srcPtr[i])
     }
-    return Tensor(result, size: size, context: context)
+    return Tensor(storage: result, size: size, context: context)
   }
   
   static func /(lhs: Scalar, rhs: Tensor) -> Tensor {
@@ -1145,13 +1147,11 @@ public extension Tensor {
   }
   
   func zerosLike() -> Tensor {
-    let zeroStorage = Tensor.Value(repeating: 0, count: storage.count)
-    return Tensor(zeroStorage, size: size)
+    return Tensor(storage: TensorStorage.create(count: storage.count), size: size)
   }
   
   func onesLike() -> Tensor {
-    let oneStorage = Tensor.Value(repeating: 1, count: storage.count)
-    return Tensor(oneStorage, size: size)
+    return Tensor(storage: TensorStorage.create(repeating: 1, count: storage.count), size: size)
   }
   
   func transposed() -> Tensor {

--- a/Sources/Neuron/Tensor/TensorMath.swift
+++ b/Sources/Neuron/Tensor/TensorMath.swift
@@ -573,6 +573,8 @@ public extension Tensor {
     let columns = size.columns
     let rows = size.rows
     let depth = size.depth
+    let selfPtr = storage.pointer
+    let sliceSize = rows * columns
     
     if axis == 2 {
       let chunkCount = (depth + into - 1) / into
@@ -584,19 +586,18 @@ public extension Tensor {
         let dEnd = min(dStart + into, depth)
         let chunkDepth = dEnd - dStart
         let newSize = TensorSize(rows: rows, columns: columns, depth: chunkDepth)
-        var chunkStorage = Tensor.Value(repeating: 0, count: columns * rows * chunkDepth)
+        let chunkStorage = TensorStorage.create(count: sliceSize * chunkDepth)
+        let dstPtr = chunkStorage.pointer
         
         for d in 0..<chunkDepth {
-          let srcDepth = dStart + d
-          let srcStart = flatIndex(column: 0, row: 0, depth: srcDepth)
-          let dstStart = d * rows * columns
-          for i in 0..<(rows * columns) {
-            let srcIdx = srcStart + i
-            chunkStorage[dstStart + i] = srcIdx < storage.count ? storage[srcIdx] : 0
+          let srcStart = flatIndex(column: 0, row: 0, depth: dStart + d)
+          let copyCount = min(sliceSize, storage.count - srcStart)
+          if copyCount > 0 {
+            (dstPtr + d * sliceSize).update(from: selfPtr + srcStart, count: copyCount)
           }
         }
         
-        results.append(Tensor(chunkStorage, size: newSize))
+        results.append(Tensor(storage: chunkStorage, size: newSize))
       }
       return results
       
@@ -610,20 +611,21 @@ public extension Tensor {
         let rEnd = min(rStart + into, rows)
         let chunkRows = rEnd - rStart
         let newSize = TensorSize(rows: chunkRows, columns: columns, depth: depth)
-        var chunkStorage = Tensor.Value(repeating: 0, count: columns * chunkRows * depth)
+        let chunkStorage = TensorStorage.create(count: columns * chunkRows * depth)
+        let dstPtr = chunkStorage.pointer
         
         for d in 0..<depth {
           for r in 0..<chunkRows {
             let srcStart = flatIndex(column: 0, row: rStart + r, depth: d)
             let dstStart = d * chunkRows * columns + r * columns
-            for c in 0..<columns {
-              let srcIdx = srcStart + c
-              chunkStorage[dstStart + c] = srcIdx < storage.count ? storage[srcIdx] : 0
+            let copyCount = min(columns, storage.count - srcStart)
+            if copyCount > 0 {
+              (dstPtr + dstStart).update(from: selfPtr + srcStart, count: copyCount)
             }
           }
         }
         
-        results.append(Tensor(chunkStorage, size: newSize))
+        results.append(Tensor(storage: chunkStorage, size: newSize))
       }
       return results
       
@@ -637,19 +639,20 @@ public extension Tensor {
         let cEnd = min(cStart + into, columns)
         let chunkCols = cEnd - cStart
         let newSize = TensorSize(rows: rows, columns: chunkCols, depth: depth)
-        var chunkStorage = Tensor.Value(repeating: 0, count: chunkCols * rows * depth)
+        let chunkStorage = TensorStorage.create(count: chunkCols * rows * depth)
+        let dstPtr = chunkStorage.pointer
         
         for d in 0..<depth {
           for r in 0..<rows {
             let dstStart = d * rows * chunkCols + r * chunkCols
             for c in 0..<chunkCols {
               let srcIdx = flatIndex(column: cStart + c, row: r, depth: d)
-              chunkStorage[dstStart + c] = srcIdx < storage.count ? storage[srcIdx] : 0
+              dstPtr[dstStart + c] = srcIdx < storage.count ? selfPtr[srcIdx] : 0
             }
           }
         }
         
-        results.append(Tensor(chunkStorage, size: newSize))
+        results.append(Tensor(storage: chunkStorage, size: newSize))
       }
       return results
       

--- a/Sources/Neuron/Tensor/TensorMath.swift
+++ b/Sources/Neuron/Tensor/TensorMath.swift
@@ -822,54 +822,50 @@ public extension Tensor {
       // Concat along rows
       let newRows = selfRows + otherRows
       let newSize = TensorSize(rows: newRows, columns: selfCols, depth: selfDepth)
-      var result = Tensor.Value(repeating: 0, count: selfCols * newRows * selfDepth)
+      let result = TensorStorage.create(count: selfCols * newRows * selfDepth)
+      let dstPtr = result.pointer
+      let selfPtr = storage.pointer
+      let otherPtr = tensor.storage.pointer
       
       for d in 0..<selfDepth {
         for r in 0..<selfRows {
           let srcStart = flatIndex(column: 0, row: r, depth: d)
           let dstStart = d * newRows * selfCols + r * selfCols
-          for c in 0..<selfCols {
-            result[dstStart + c] = storage[srcStart + c]
-          }
+          (dstPtr + dstStart).update(from: selfPtr + srcStart, count: selfCols)
         }
         let minOtherRows = min(otherRows, (d < otherDepth) ? otherRows : 0)
         for r in 0..<minOtherRows {
           let srcStart = tensor.flatIndex(column: 0, row: r, depth: d)
           let dstStart = d * newRows * selfCols + (selfRows + r) * selfCols
           let colsToCopy = min(otherCols, selfCols)
-          for c in 0..<colsToCopy {
-            result[dstStart + c] = tensor.storage[srcStart + c]
-          }
+          (dstPtr + dstStart).update(from: otherPtr + srcStart, count: colsToCopy)
         }
       }
       
-      return Tensor(result, size: newSize, context: context)
+      return Tensor(storage: result, size: newSize, context: context)
       
     } else if axis == 1 {
       // Concat along columns
       let newCols = selfCols + otherCols
       let newSize = TensorSize(rows: selfRows, columns: newCols, depth: selfDepth)
-      var result = Tensor.Value(repeating: 0, count: newCols * selfRows * selfDepth)
+      let result = TensorStorage.create(count: newCols * selfRows * selfDepth)
+      let dstPtr = result.pointer
+      let selfPtr = storage.pointer
+      let otherPtr = tensor.storage.pointer
       
       for d in 0..<selfDepth {
         for r in 0..<selfRows {
           let dstStart = d * selfRows * newCols + r * newCols
-          // Copy self row
           let srcSelfStart = flatIndex(column: 0, row: r, depth: d)
-          for c in 0..<selfCols {
-            result[dstStart + c] = storage[srcSelfStart + c]
-          }
-          // Copy other row
+          (dstPtr + dstStart).update(from: selfPtr + srcSelfStart, count: selfCols)
           if d < otherDepth && r < otherRows {
             let srcOtherStart = tensor.flatIndex(column: 0, row: r, depth: d)
-            for c in 0..<otherCols {
-              result[dstStart + selfCols + c] = tensor.storage[srcOtherStart + c]
-            }
+            (dstPtr + dstStart + selfCols).update(from: otherPtr + srcOtherStart, count: otherCols)
           }
         }
       }
       
-      return Tensor(result, size: newSize, context: context)
+      return Tensor(storage: result, size: newSize, context: context)
     }
     
     return Tensor(storage: storage.copy(), size: size, context: context)

--- a/Sources/Neuron/Tensor/TensorMath.swift
+++ b/Sources/Neuron/Tensor/TensorMath.swift
@@ -1027,8 +1027,15 @@ public extension Tensor {
     
     if let new = lhs._broadcastPerChannelFastPath(value: rhs, op: .mul) {
       new.label = "multiplication"
-      if lhs.graphChain.contains(rhs.id) { new.setGraphSafe(lhs); new.setGraphSafe(rhs) }
-      else { new.setGraphSafe(rhs); new.setGraphSafe(lhs) }
+      
+      if lhs.graphChain.contains(rhs.id) {
+        new.setGraphSafe(lhs)
+        new.setGraphSafe(rhs)
+      } else {
+        new.setGraphSafe(rhs)
+        new.setGraphSafe(lhs)
+      }
+      
       return new
     }
     

--- a/Sources/Neuron/Tensor/TensorMath.swift
+++ b/Sources/Neuron/Tensor/TensorMath.swift
@@ -24,7 +24,6 @@ public extension Float16 {
 
 public extension Tensor {
   typealias PointerMathBlock = (_ ptr: TensorStorage.Pointer, _ count: Int) -> Scalar
-  typealias MathAlongBlock = (_ feature: [Scalar], _ value: ([Scalar]?, Scalar?)) -> [Scalar]
   
   /*
       +--------+
@@ -276,68 +275,6 @@ public extension Tensor {
     return Tensor(storage: resultStorage, size: selfSize, context: context)
   }
   
-  /// Applies a mathematical operation along a specific axis with broadcasting support.
-  /// This is the core function used by other *Along methods.
-  ///
-  /// - Parameters:
-  ///   - axis: The axis along which to perform the operation (0, 1, or 2)
-  ///   - input: The tensor to operate with, which will be broadcast along the specified axis
-  ///   - block: The mathematical operation to apply
-  /// - Returns: A new tensor with the result of the operation
-  ///
-  /// - Note: Self-assignment is supported. Methods using this function automatically detect and prevent
-  ///   reference cycles in the computation graph via ` `.
-  func applyAlong(axis: Int, input: Tensor, _ block: MathAlongBlock) -> Tensor {
-    let inputSize = input.size
-    let selfSize = self.size
-    let columns = selfSize.columns
-    let rows = selfSize.rows
-    let depth = selfSize.depth
-        
-    var result: Tensor.Value = []
-    result.reserveCapacity(selfSize.depth * selfSize.rows * selfSize.columns)
-    
-    for d in 0..<depth {
-      for r in 0..<rows {
-        // Extract the row from self
-        let selfStart = flatIndex(column: 0, row: r, depth: d)
-        let feature = storage[safe: selfStart..<(selfStart + columns), 0]
-        
-        let out: [Scalar]
-        
-        if axis == 0,
-           inputSize.columns == columns,
-           inputSize.rows == 1,
-           inputSize.depth == depth {
-          let inputStart = input.flatIndex(column: 0, row: 0, depth: d)
-          let v = input.storage[safe: inputStart..<(inputStart + inputSize.columns), 0]
-          out = block(feature, (v, nil))
-          
-        } else if axis == 1,
-                  inputSize.columns == 1,
-                  inputSize.rows == rows,
-                  inputSize.depth == depth {
-          let v = input.storage[safe: input.flatIndex(column: 0, row: r, depth: d), 0]
-          out = block(feature, (nil, v))
-          
-        } else if axis == 2,
-                  inputSize.columns == columns,
-                  inputSize.rows == rows,
-                  inputSize.depth == 1 {
-          let inputStart = input.flatIndex(column: 0, row: r, depth: 0)
-          let v = input.storage[safe: inputStart..<(inputStart + inputSize.columns), 0]
-          out = block(feature, (v, nil))
-        } else {
-          out = feature
-        }
-        
-        result.append(contentsOf: out)
-      }
-    }
-    
-    return Tensor(result, size: selfSize)
-  }
-  
   func divideContext(value: Tensor) -> TensorContext {
     let branchNode: Tensor? = if sharesGraph(with: value) {
       if self.graphChain.contains(value.id) {
@@ -381,21 +318,7 @@ public extension Tensor {
       else { new.setGraphSafe(value); new.setGraphSafe(self) }
       return new
     }
-    let block: MathAlongBlock = { feature, value in
-      if let valueArray = value.0 {
-        return feature / valueArray
-      } else if let valueScalar = value.1 {
-        return feature / valueScalar
-      } else {
-        return feature
-      }
-    }
-    let out = applyAlong(axis: axis, input: value, block)
-    let new = Tensor(storage: out.storage, size: out.size, context: divideContext(value: value))
-    new.label = "division"
-    if graphChain.contains(value.id) { new.setGraphSafe(self); new.setGraphSafe(value) }
-    else { new.setGraphSafe(value); new.setGraphSafe(self) }
-    return new
+    return Tensor(storage: storage.copy(), size: size, context: divideContext(value: value))
   }
   
   func multiplyContext(value: Tensor) -> TensorContext {
@@ -441,21 +364,7 @@ public extension Tensor {
       else { new.setGraphSafe(value); new.setGraphSafe(self) }
       return new
     }
-    let block: MathAlongBlock = { feature, value in
-      if let valueArray = value.0 {
-        return feature * valueArray
-      } else if let valueScalar = value.1 {
-        return feature * valueScalar
-      } else {
-        return feature
-      }
-    }
-    let out = applyAlong(axis: axis, input: value, block)
-    let new = Tensor(storage: out.storage, size: out.size, context: multiplyContext(value: value))
-    new.label = "multiplication"
-    if graphChain.contains(value.id) { new.setGraphSafe(self); new.setGraphSafe(value) }
-    else { new.setGraphSafe(value); new.setGraphSafe(self) }
-    return new
+    return Tensor(storage: storage.copy(), size: size, context: multiplyContext(value: value))
   }
   
   func addContext(value: Tensor) -> TensorContext {
@@ -516,33 +425,7 @@ public extension Tensor {
       else { new.setGraphSafe(value); new.setGraphSafe(self) }
       return new
     }
-    // Fallback: generic applyAlong path
-    let block: MathAlongBlock = { feature, value in
-      if let valueArray = value.0 {
-        return feature + valueArray
-      } else if let valueScalar = value.1 {
-        return feature + valueScalar
-      } else {
-        return feature
-      }
-    }
-    let out = applyAlong(axis: axis, input: value, block)
-    
-    let new = Tensor(storage: out.storage, size: out.size, context: addContext(value: value))
-    
-    new.label = "addition"
-
-    if graphChain.contains(value.id) {
-      // non branched node
-      new.setGraphSafe(self)
-      new.setGraphSafe(value)
-    } else {
-      // branched node
-      new.setGraphSafe(value)
-      new.setGraphSafe(self)
-    }
-    
-    return new
+    return Tensor(storage: storage.copy(), size: size, context: addContext(value: value))
   }
   
   func subtractContext(value: Tensor) -> TensorContext {
@@ -590,21 +473,7 @@ public extension Tensor {
       else { new.setGraphSafe(value); new.setGraphSafe(self) }
       return new
     }
-    let block: MathAlongBlock = { feature, value in
-      if let valueArray = value.0 {
-        return feature - valueArray
-      } else if let valueScalar = value.1 {
-        return feature - valueScalar
-      } else {
-        return feature
-      }
-    }
-    let out = applyAlong(axis: axis, input: value, block)
-    let new = Tensor(storage: out.storage, size: out.size, context: subtractContext(value: value))
-    new.label = "subtraction"
-    if graphChain.contains(value.id) { new.setGraphSafe(self); new.setGraphSafe(value) }
-    else { new.setGraphSafe(value); new.setGraphSafe(self) }
-    return new
+    return Tensor(storage: storage.copy(), size: size, context: subtractContext(value: value))
   }
   
   func sum() -> Scalar {

--- a/Sources/Neuron/Tensor/TensorMath.swift
+++ b/Sources/Neuron/Tensor/TensorMath.swift
@@ -23,7 +23,7 @@ public extension Float16 {
 #endif
 
 public extension Tensor {
-  typealias MathBlock = (_ feature: [Scalar]) -> Scalar
+  typealias PointerMathBlock = (_ ptr: TensorStorage.Pointer, _ count: Int) -> Scalar
   typealias MathAlongBlock = (_ feature: [Scalar], _ value: ([Scalar]?, Scalar?)) -> [Scalar]
   
   /*
@@ -44,61 +44,64 @@ public extension Tensor {
    
    Along axis -1 the Tensor of shape AxBxC, where A is the columns, B is the rows, and C is the depth, would perform a mathematical function along the Z axis returning a (1x1x1) Tensor Scalar
    */
-  func apply(axis: Int, _ block: MathBlock) -> Tensor {
+  func apply(axis: Int, _ block: PointerMathBlock) -> Tensor {
     let columns = size.columns
     let rows = size.rows
     let depth = size.depth
+    let selfPtr = storage.pointer
     
     if axis == 0 {
       // Reduce along rows -> output (columns x 1 x depth)
       let outSize = TensorSize(rows: 1, columns: columns, depth: depth)
-      var outStorage = Tensor.Value(repeating: 0, count: columns * depth)
+      let outStorage = TensorStorage.create(count: columns * depth)
+      let outPtr = outStorage.pointer
+      let scratch = TensorStorage.create(count: rows)
+      let scratchPtr = scratch.pointer
       
       for d in 0..<depth {
         for c in 0..<columns {
-          var workingRow = [Scalar]()
-          workingRow.reserveCapacity(rows)
           for r in 0..<rows {
-            workingRow.append(storage[flatIndex(column: c, row: r, depth: d)])
+            scratchPtr[r] = selfPtr[flatIndex(column: c, row: r, depth: d)]
           }
-          outStorage[d * columns + c] = block(workingRow)
+          outPtr[d * columns + c] = block(scratchPtr, rows)
         }
       }
       
-      return Tensor(outStorage, size: outSize)
+      return Tensor(storage: outStorage, size: outSize)
       
     } else if axis == 1 {
       // Reduce along columns -> output (1 x rows x depth)
       let outSize = TensorSize(rows: rows, columns: 1, depth: depth)
-      var outStorage = Tensor.Value(repeating: 0, count: rows * depth)
+      let outStorage = TensorStorage.create(count: rows * depth)
+      let outPtr = outStorage.pointer
       
       for d in 0..<depth {
         for r in 0..<rows {
           let start = flatIndex(column: 0, row: r, depth: d)
-          let row = Array(storage[start..<(start + columns)])
-          outStorage[d * rows + r] = block(row)
+          outPtr[d * rows + r] = block(selfPtr + start, columns)
         }
       }
       
-      return Tensor(outStorage, size: outSize)
+      return Tensor(storage: outStorage, size: outSize)
       
     } else if axis == 2 {
       // Reduce along depth -> output (columns x rows x 1)
       let outSize = TensorSize(rows: rows, columns: columns, depth: 1)
-      var outStorage = Tensor.Value(repeating: 0, count: columns * rows)
+      let outStorage = TensorStorage.create(count: columns * rows)
+      let outPtr = outStorage.pointer
+      let scratch = TensorStorage.create(count: depth)
+      let scratchPtr = scratch.pointer
       
       for r in 0..<rows {
         for c in 0..<columns {
-          var featureR = [Scalar]()
-          featureR.reserveCapacity(depth)
           for d in 0..<depth {
-            featureR.append(storage[flatIndex(column: c, row: r, depth: d)])
+            scratchPtr[d] = selfPtr[flatIndex(column: c, row: r, depth: d)]
           }
-          outStorage[r * columns + c] = block(featureR)
+          outPtr[r * columns + c] = block(scratchPtr, depth)
         }
       }
       
-      return Tensor(outStorage, size: outSize)
+      return Tensor(storage: outStorage, size: outSize)
     }
     
     return Tensor(storage: storage, size: size)
@@ -688,15 +691,13 @@ public extension Tensor {
   }
   
   func sumOfSquares(axis: Int = -1) -> Tensor {
-    let block: MathBlock = { feature in
-      feature.sumOfSquares
-    }
-    
     if axis == -1 {
       return Tensor(storage.sumOfSquares)
     }
     
-    return apply(axis: axis, block)
+    return apply(axis: axis) { ptr, count in
+      NumSwiftFlat.sumOfSquares(ptr, count: count)
+    }
   }
   
   func split(into: Int, axis: Int = 2) -> [Tensor] {
@@ -795,15 +796,6 @@ public extension Tensor {
   }
   
   func variance(axis: Int = -1) -> Tensor {
-    let block: MathBlock = { feature in
-      let mean = feature.mean
-      let sumOSquares = (feature - mean).sumOfSquares
-      
-      let count = feature.count
-      
-      return sumOSquares / Tensor.Scalar(count)
-    }
-    
     if axis == -1 {
       let meanVal = storage.mean
       let centered = storage - meanVal
@@ -811,28 +803,34 @@ public extension Tensor {
       return Tensor(sumSq / Scalar(storage.count))
     }
     
-    return apply(axis: axis, block)
+    return apply(axis: axis) { ptr, count in
+      let mean = NumSwiftFlat.mean(ptr, count: count)
+      var sumSq: Tensor.Scalar = 0
+      for i in 0..<count {
+        let diff = ptr[i] - mean
+        sumSq += diff * diff
+      }
+      return sumSq / Tensor.Scalar(count)
+    }
   }
   
   func mean(axis: Int = -1) -> Tensor {
-    let block: MathBlock = { feature in
-      feature.mean
-    }
-    
     if axis == -1 {
       guard !storage.isEmpty else { return Tensor(Scalar(0)) }
       return Tensor(storage.mean)
     }
     
-    return apply(axis: axis, block)
+    return apply(axis: axis) { ptr, count in
+      NumSwiftFlat.mean(ptr, count: count)
+    }
   }
   
   func sum(axis: Int = -1) -> Tensor {
     if axis == -1 {
       return Tensor(storage.sum)
     } else {
-      return apply(axis: axis) { feature in
-        feature.sum
+      return apply(axis: axis) { ptr, count in
+        NumSwiftFlat.sum(ptr, count: count)
       }
     }
   }
@@ -846,11 +844,13 @@ public extension Tensor {
       }
       return Tensor(result)
     } else {
-      return apply(axis: axis) { feature in
-        var feature = feature
-        let first = feature.first ?? 0
-        feature = Array(feature.dropFirst())
-        return feature.reduce(first, -)
+      return apply(axis: axis) { ptr, count in
+        guard count > 0 else { return 0 }
+        var result = ptr[0]
+        for i in 1..<count {
+          result -= ptr[i]
+        }
+        return result
       }
     }
   }
@@ -864,22 +864,24 @@ public extension Tensor {
       }
       return Tensor(result)
     } else {
-      return apply(axis: axis) { feature in
-        feature.reduce(1, *)
+      return apply(axis: axis) { ptr, count in
+        var result: Tensor.Scalar = 1
+        for i in 0..<count {
+          result *= ptr[i]
+        }
+        return result
       }
     }
   }
   
   func norm(axis: Int = -1) -> Tensor {
-    let block: MathBlock = { feature in
-      Tensor.Scalar.sqrt(feature.sumOfSquares)
-    }
-    
     if axis == -1 {
       return Tensor(Tensor.Scalar.sqrt(storage.sumOfSquares))
     }
     
-    return apply(axis: axis, block)
+    return apply(axis: axis) { ptr, count in
+      Tensor.Scalar.sqrt(NumSwiftFlat.sumOfSquares(ptr, count: count))
+    }
   }
   
   @discardableResult

--- a/Sources/Neuron/Tensor/TensorMath.swift
+++ b/Sources/Neuron/Tensor/TensorMath.swift
@@ -174,14 +174,62 @@ public extension Tensor {
       }
     }
 
-    let context: TensorContext
-    switch op {
-    case .add: context = addContext(value: value)
-    case .sub: context = subtractContext(value: value)
-    case .mul: context = multiplyContext(value: value)
-    case .div: context = divideContext(value: value)
-    }
+    let context = _perChannelBroadcastContext(value: value, op: op)
     return Tensor(storage: resultStorage, size: selfSize, context: context)
+  }
+
+  /// Specialized context for (H,W,C) op (1,1,C) broadcast operations.
+  /// Correctly reduces gradients spatially (sum over H,W) when backpropagating
+  /// through the `value (1,1,C)` path, avoiding the shape mismatch that the
+  /// generic arithmetic contexts produce.
+  private func _perChannelBroadcastContext(value: Tensor, op: _BroadcastOp) -> TensorContext {
+    // `self` is (H,W,C), `value` is (1,1,C)
+    let selfCapture = self
+    let valueSize = value.size
+
+    func reduceSpatial(_ t: Tensor) -> Tensor {
+      let depth = valueSize.depth
+      let sliceSize = t.size.rows * t.size.columns
+      let sumStorage = TensorStorage.create(count: depth)
+      let srcPtr = t.storage.pointer
+      for d in 0..<depth {
+        var s: Tensor.Scalar = 0
+        let base = d * sliceSize
+        for i in 0..<sliceSize { s += srcPtr[base + i] }
+        sumStorage[d] = s
+      }
+      return Tensor(storage: sumStorage, size: valueSize)
+    }
+
+    return TensorContext { inputs, gradient, wrt in
+      if value.graphChain.contains(wrt.id) || value.id == wrt.id {
+        // Gradient w.r.t. value (1,1,C) — reduce spatial dims back to (1,1,C)
+        switch op {
+        case .add:
+          return (reduceSpatial(gradient), Tensor(), Tensor())
+        case .sub:
+          return (reduceSpatial(gradient * Tensor.Scalar(-1)), Tensor(), Tensor())
+        case .mul:
+          return (reduceSpatial(gradient * selfCapture.copy()), Tensor(), Tensor())
+        case .div:
+          let valueSq = value * value
+          let ratio = selfCapture.copy() / valueSq
+          return (reduceSpatial(gradient * ratio * Tensor.Scalar(-1)), Tensor(), Tensor())
+        }
+      } else {
+        // Gradient w.r.t. self (H,W,C) — broadcast, no reduction needed
+        switch op {
+        case .add:
+          return (gradient, Tensor(), Tensor())
+        case .sub:
+          return (gradient, Tensor(), Tensor())
+        case .mul:
+          return (gradient * value.copy(), Tensor(), Tensor())
+        case .div:
+          return (gradient / value.copy(), Tensor(), Tensor())
+        }
+      }
+    }
   }
 
   /// Pointer-based fast path for *Along broadcasting. Returns result storage when applicable, nil to fall back.

--- a/Sources/Neuron/Tensor/TensorSize.swift
+++ b/Sources/Neuron/Tensor/TensorSize.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 /// Object that defines a size of a Tensor
-public struct TensorSize: Codable, Equatable {
+public struct TensorSize: Codable, Equatable, Comparable {
+
   /// The number of rows in the tensor.
   public let rows: Int
   /// The number of columns in the tensor.
@@ -40,6 +41,16 @@ public struct TensorSize: Codable, Equatable {
   public enum CodingKeys: String, CodingKey {
     case rows, columns, depth, batchCount
   }
+  
+  public static func < (lhs: TensorSize, rhs: TensorSize) -> Bool {
+    (lhs.columns * lhs.rows * lhs.depth) < (rhs.columns * rhs.rows * rhs.depth)
+  }
+  
+  
+  public static func > (lhs: TensorSize, rhs: TensorSize) -> Bool {
+    (lhs.columns * lhs.rows * lhs.depth) > (rhs.columns * rhs.rows * rhs.depth)
+  }
+  
   
   /// Creates a `TensorSize` by decoding from the given decoder.
   /// - Parameter decoder: The decoder to read data from.

--- a/Sources/Neuron/Trainable/Sequential.swift
+++ b/Sources/Neuron/Trainable/Sequential.swift
@@ -245,7 +245,12 @@ public final class Sequential: Trainable, Logger {
     
     var errorMsg: String = ""
     
+    var linkLayers: [String: Layer] = [:]
+    
     for layer in layers {
+      
+      linkLayers[layer.linkId] = layer
+      
       if i == 0 && layer.inputSize.isEmpty {
         fatalError("The first layer should contain an input size")
       }
@@ -264,9 +269,17 @@ public final class Sequential: Trainable, Logger {
         }
         
         layer.inputSize = inputSize
+        
+        // set outputSize to be the larger of the two sizes 
+        if let mathLayer = layer as? ArithmeticLayer,
+           let linkedLayer = linkLayers[mathLayer.linkTo]  {
+          mathLayer.outputSize = max(inputSize, linkedLayer.outputSize)
+        }
       }
       
       inputSize = layer.outputSize
+
+      
       i += 1
     }
     

--- a/Tests/NeuronTests/LayerTests.swift
+++ b/Tests/NeuronTests/LayerTests.swift
@@ -1264,7 +1264,7 @@ final class LayerTests: XCTestCase {
     
     let gradients = out.gradients(delta: error, wrt: input)
     
-    XCTAssertEqual(resNet.innerBlockSequential.layers.count, 14)
+    XCTAssertEqual(resNet.innerBlockSequential.layers.count, 15)
     
     let totalWeights = resNet.innerBlockSequential.layers.filter(\.usesOptimizer).reduce(into: 0) { $0 = $0 + $1.weights.size.columns * $1.weights.size.rows * $1.weights.size.depth }
     

--- a/Tests/NeuronTests/NeuronTests.swift
+++ b/Tests/NeuronTests/NeuronTests.swift
@@ -561,7 +561,7 @@ final class NeuronTests: XCTestCase {
     // Per-channel statistics: depth=1, all values across batch + spatial
     // 5 even [0,1,0,1,0] + 5 odd [1,0,1,0,1] → mean=0.5, var=0.25, std≈0.5
     XCTAssertEqual(norm.sampleCount, batchSize)
-    XCTAssertEqual(norm.movingMean.count, 1)
+    XCTAssertEqual(norm.movingMean.storage.count, 1)
   }
   
   func testBatchNorm2d() {
@@ -651,7 +651,7 @@ final class NeuronTests: XCTestCase {
     
     XCTAssertEqual(norm.sampleCount, batchSize)
     // Per-channel: 5 channels, each with mean=0.5, var=0.25 (same data pattern per channel)
-    XCTAssertEqual(norm.movingMean.count, 5)
+    XCTAssertEqual(norm.movingMean.storage.count, 5)
   }
   
   func testDropout() {

--- a/Tests/NeuronTests/NeuronTests.swift
+++ b/Tests/NeuronTests/NeuronTests.swift
@@ -855,19 +855,184 @@ final class NeuronTests: XCTestCase {
     // Ragged 3D array: different row sizes in different depth slices
     let ragged: Tensor.Data = [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9]]]
     let tensor = Tensor(ragged)
-    
+
     // Should normalize to max dimensions: cols=3, rows=2, depth=2
     XCTAssertEqual(tensor.shape, [3, 2, 2])
     XCTAssertEqual(tensor.storage.count, 12)
-    
+
     // First depth slice: [1,2,3], [4,5,6]
     XCTAssertEqual(tensor[0, 0, 0], 1)
     XCTAssertEqual(tensor[2, 1, 0], 6)
-    
+
     // Second depth slice: [7,8,9], then zero-padded row
     XCTAssertEqual(tensor[0, 0, 1], 7)
     XCTAssertEqual(tensor[2, 0, 1], 9)
     XCTAssertEqual(tensor[0, 1, 1], 0) // zero-padded
   }
-  
+
+  // MARK: - Per-channel broadcast context gradient tests
+  // Covers _perChannelBroadcastContext for all four ops.
+  // Layout: self is (cols:2, rows:2, depth:2), value is (cols:1, rows:1, depth:2).
+  // self depth-0 slice = [1,2,3,4], depth-1 slice = [5,6,7,8]
+  // value = [scale0, scale1]  (one scalar per depth)
+
+  /// Helper: build a (2,2,2) self tensor and (1,1,2) value tensor, run the op,
+  /// then return gradients w.r.t. both self and value.
+  private func perChannelBroadcastGrads(
+    op: (Tensor, Tensor) -> Tensor,
+    selfValues: [Tensor.Scalar],
+    scaleValues: [Tensor.Scalar],
+    gradValues: [Tensor.Scalar]
+  ) -> (wrtSelf: Tensor, wrtValue: Tensor) {
+    let selfSize  = TensorSize(rows: 2, columns: 2, depth: 2)
+    let valueSize = TensorSize(rows: 1, columns: 1, depth: 2)
+
+    let lhs = Tensor(Tensor.Value(selfValues), size: selfSize)
+    let rhs = Tensor(Tensor.Value(scaleValues), size: valueSize)
+    lhs.label = "lhs"
+    rhs.label = "rhs"
+
+    let out = op(lhs, rhs)
+    out.setGraph(lhs)
+    out.setGraph(rhs)
+
+    let gradTensor = Tensor(Tensor.Value(gradValues), size: selfSize)
+    let wrtSelf  = out.gradients(delta: gradTensor, wrt: lhs).input.first!
+    let wrtValue = out.gradients(delta: gradTensor, wrt: rhs).input.first!
+    return (wrtSelf, wrtValue)
+  }
+
+  func testPerChannelBroadcast_add_forward() {
+    // (2×2×2) + (1×1×2): each spatial slice of depth d gets scale[d] added
+    let lhs = Tensor(Tensor.Value([1,2,3,4,5,6,7,8]), size: TensorSize(rows: 2, columns: 2, depth: 2))
+    let rhs = Tensor(Tensor.Value([10, 20]), size: TensorSize(rows: 1, columns: 1, depth: 2))
+    let out = lhs + rhs
+    // depth-0: [1+10,2+10,3+10,4+10] = [11,12,13,14]
+    // depth-1: [5+20,6+20,7+20,8+20] = [25,26,27,28]
+    XCTAssertEqual(out.asArray, [11,12,13,14,25,26,27,28])
+  }
+
+  func testPerChannelBroadcast_add_gradWrtSelf() {
+    // d(out)/d(self) for add = 1 → grad passes through unchanged
+    let grads = perChannelBroadcastGrads(
+      op: +,
+      selfValues:  [1,2,3,4,5,6,7,8],
+      scaleValues: [10,20],
+      gradValues:  [1,1,1,1,1,1,1,1]
+    )
+    XCTAssertEqual(grads.wrtSelf.shape, [2,2,2])
+    XCTAssertEqual(grads.wrtSelf.asArray, [1,1,1,1,1,1,1,1])
+  }
+
+  func testPerChannelBroadcast_add_gradWrtValue() {
+    // d(out)/d(value) for add = 1 → grad is summed spatially per channel
+    // all-ones gradient: sum over 4 spatial elements per depth → [4, 4]
+    let grads = perChannelBroadcastGrads(
+      op: +,
+      selfValues:  [1,2,3,4,5,6,7,8],
+      scaleValues: [10,20],
+      gradValues:  [1,1,1,1,1,1,1,1]
+    )
+    XCTAssertEqual(grads.wrtValue.shape, [1,1,2])
+    XCTAssertEqual(grads.wrtValue.asArray, [4,4])
+  }
+
+  func testPerChannelBroadcast_sub_gradWrtSelf() {
+    // d(out)/d(self) for sub = 1 → grad passes through unchanged
+    let grads = perChannelBroadcastGrads(
+      op: -,
+      selfValues:  [1,2,3,4,5,6,7,8],
+      scaleValues: [1,2],
+      gradValues:  [1,1,1,1,2,2,2,2]
+    )
+    XCTAssertEqual(grads.wrtSelf.shape, [2,2,2])
+    XCTAssertEqual(grads.wrtSelf.asArray, [1,1,1,1,2,2,2,2])
+  }
+
+  func testPerChannelBroadcast_sub_gradWrtValue() {
+    // d(out)/d(value) for sub = -1 → spatial sum of -gradient
+    // depth-0: sum(−1,−1,−1,−1) = −4; depth-1: sum(−2,−2,−2,−2) = −8
+    let grads = perChannelBroadcastGrads(
+      op: -,
+      selfValues:  [1,2,3,4,5,6,7,8],
+      scaleValues: [1,2],
+      gradValues:  [1,1,1,1,2,2,2,2]
+    )
+    XCTAssertEqual(grads.wrtValue.shape, [1,1,2])
+    XCTAssertEqual(grads.wrtValue.asArray, [-4,-8])
+  }
+
+  func testPerChannelBroadcast_mul_gradWrtSelf() {
+    // d(out)/d(self) for mul = value (broadcast) → grad * scale
+    // depth-0 elements × scale0=2: [1,1,1,1]*2=[2,2,2,2]
+    // depth-1 elements × scale1=3: [1,1,1,1]*3=[3,3,3,3]
+    let grads = perChannelBroadcastGrads(
+      op: *,
+      selfValues:  [1,2,3,4,5,6,7,8],
+      scaleValues: [2,3],
+      gradValues:  [1,1,1,1,1,1,1,1]
+    )
+    XCTAssertEqual(grads.wrtSelf.shape, [2,2,2])
+    XCTAssertEqual(grads.wrtSelf.asArray, [2,2,2,2,3,3,3,3])
+  }
+
+  func testPerChannelBroadcast_mul_gradWrtValue() {
+    // d(out)/d(value) for mul = spatial sum of (grad * self)
+    // depth-0: sum([1*1,1*2,1*3,1*4]) = 10; depth-1: sum([1*5,1*6,1*7,1*8]) = 26
+    let grads = perChannelBroadcastGrads(
+      op: *,
+      selfValues:  [1,2,3,4,5,6,7,8],
+      scaleValues: [2,3],
+      gradValues:  [1,1,1,1,1,1,1,1]
+    )
+    XCTAssertEqual(grads.wrtValue.shape, [1,1,2])
+    XCTAssertEqual(grads.wrtValue.asArray, [10,26])
+  }
+
+  func testPerChannelBroadcast_div_gradWrtSelf() {
+    // d(out)/d(self) for div = 1/value (broadcast)
+    // depth-0: grad / scale0=2 → [0.5,0.5,0.5,0.5]
+    // depth-1: grad / scale1=4 → [0.25,0.25,0.25,0.25]
+    let grads = perChannelBroadcastGrads(
+      op: /,
+      selfValues:  [1,2,3,4,5,6,7,8],
+      scaleValues: [2,4],
+      gradValues:  [1,1,1,1,1,1,1,1]
+    )
+    XCTAssertEqual(grads.wrtSelf.shape, [2,2,2])
+    for v in grads.wrtSelf.asArray.prefix(4) { XCTAssertEqual(v, 0.5, accuracy: 1e-5) }
+    for v in grads.wrtSelf.asArray.suffix(4) { XCTAssertEqual(v, 0.25, accuracy: 1e-5) }
+  }
+
+  func testPerChannelBroadcast_div_gradWrtValue() {
+    // d(out)/d(value) for div = spatial sum of (−grad * self / value²)
+    // depth-0: value=2 → −(1+2+3+4)/4 = −10/4 = −2.5
+    // depth-1: value=4 → −(5+6+7+8)/16 = −26/16 = −1.625
+    let grads = perChannelBroadcastGrads(
+      op: /,
+      selfValues:  [1,2,3,4,5,6,7,8],
+      scaleValues: [2,4],
+      gradValues:  [1,1,1,1,1,1,1,1]
+    )
+    XCTAssertEqual(grads.wrtValue.shape, [1,1,2])
+    XCTAssertEqual(grads.wrtValue.asArray[0], -2.5,   accuracy: 1e-5)
+    XCTAssertEqual(grads.wrtValue.asArray[1], -1.625, accuracy: 1e-5)
+  }
+
+  func testPerChannelBroadcast_noNaN_gradients() {
+    // Smoke test: no NaN or Inf gradients produced for any op
+    let selfValues:  [Tensor.Scalar] = [1,2,3,4,5,6,7,8]
+    let scaleValues: [Tensor.Scalar] = [2,3]
+    let gradValues:  [Tensor.Scalar] = [0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8]
+    let ops: [(Tensor, Tensor) -> Tensor] = [
+      { $0 + $1 }, { $0 - $1 }, { $0 * $1 }, { $0 / $1 }
+    ]
+    for op in ops {
+      let g = perChannelBroadcastGrads(op: op, selfValues: selfValues,
+                                       scaleValues: scaleValues, gradValues: gradValues)
+      for v in g.wrtSelf.asArray  { XCTAssertFalse(v.isNaN || v.isInfinite) }
+      for v in g.wrtValue.asArray { XCTAssertFalse(v.isNaN || v.isInfinite) }
+    }
+  }
+
 }


### PR DESCRIPTION
## Summary

- **Per-channel broadcasting**: Add `(W,H,D) op (1,1,D)` fast path to Tensor arithmetic operators, enabling layers to express per-channel operations (normalize, scale, bias) via standard Tensor `+`, `-`, `*`, `/` instead of manual `NumSwiftFlat` loops
- **Pointer-based `apply(axis:)` rewrite**: Replace `[Scalar]`-based `MathBlock` with `PointerMathBlock` using `TensorStorage` output/scratch buffers, eliminating intermediate array allocations in all reduction operations (sum, mean, variance, etc.)
- **Layer migrations**: Rewrite BatchNormalize, InstanceNormalize, Conv2d, TransConv2d, and DepthwiseConv2d forward/backward passes to use Tensor broadcasting instead of per-depth-slice `NumSwiftFlat` loops. BatchNormalize gamma/beta/movingMean/movingVariance converted from `[Scalar]` to `Tensor` shaped `(1,1,D)`
- **TensorMath cleanup**: Migrate `concat`, `split`, `zerosLike`, `onesLike`, and `map` to `TensorStorage` with pointer bulk copies. Remove legacy `applyAlong` fallback and `MathAlongBlock` typealias

Net result: -82 lines, fewer intermediate array allocations, and normalization/convolution layers now express math as readable Tensor expressions while retaining pointer-level performance via the broadcasting fast paths.

## Test plan

- [ ] `CI=true swift test` passes all existing tests
- [ ] Verify BatchNormalize serialization round-trip (Codable still uses `[Scalar]` arrays for `.smodel` backward compat)
- [ ] Verify InstanceNormalize gradient layout matches weights order (beta|gamma)
- [ ] Profile forward/backward pass to confirm no performance regression from Tensor broadcasting vs manual NumSwiftFlat loops