### PR TITLE
docs: add missing documentation (2026-03-22)

### DIFF
--- a/Sources/Neuron/Tensor/TensorSize.swift
+++ b/Sources/Neuron/Tensor/TensorSize.swift
@@ -42,11 +42,19 @@ public struct TensorSize: Codable, Equatable, Comparable {
     case rows, columns, depth, batchCount
   }
   
+  /// Returns a Boolean value indicating whether the total element count of the left tensor is less than that of the right tensor.
+  /// - Parameter lhs: The left-hand side `TensorSize` to compare.
+  /// - Parameter rhs: The right-hand side `TensorSize` to compare.
+  /// - Returns: `true` if the total number of elements in `lhs` is less than in `rhs`; otherwise, `false`.
   public static func < (lhs: TensorSize, rhs: TensorSize) -> Bool {
     (lhs.columns * lhs.rows * lhs.depth) < (rhs.columns * rhs.rows * rhs.depth)
   }
   
   
+  /// Returns a Boolean value indicating whether the total element count of the left tensor is greater than that of the right tensor.
+  /// - Parameter lhs: The left-hand side `TensorSize` to compare.
+  /// - Parameter rhs: The right-hand side `TensorSize` to compare.
+  /// - Returns: `true` if the total number of elements in `lhs` is greater than in `rhs`; otherwise, `false`.
   public static func > (lhs: TensorSize, rhs: TensorSize) -> Bool {
     (lhs.columns * lhs.rows * lhs.depth) > (rhs.columns * rhs.rows * rhs.depth)
   }


### PR DESCRIPTION
Added documentation for 2 public declarations across 1 files:

- `Sources/Neuron/Tensor/TensorSize.swift`