### PR TITLE
Fix model import losing Dense biases and isTraining state

### DIFF
--- a/Sources/Neuron/Layers/Dense.swift
+++ b/Sources/Neuron/Layers/Dense.swift
@@ -84,7 +84,9 @@ public final class Dense: BaseLayer {
     precondition(inputSize.rows == 1 && inputSize.depth == 1, "Dense expects Tensor dimensions of Nx1x1 where N is the columns, got: \(inputSize)")
     
     initializeWeights(inputs: inputSize.columns)
-    self.biases = Tensor([Tensor.Scalar](repeating: 0, count: outputSize.columns))
+    if biases.isEmpty {
+      self.biases = Tensor([Tensor.Scalar](repeating: 0, count: outputSize.columns))
+    }
   }
   
   private func initializeWeights(inputs: Int) {

--- a/Sources/Neuron/Layers/DepthwiseConv2d.swift
+++ b/Sources/Neuron/Layers/DepthwiseConv2d.swift
@@ -154,7 +154,7 @@ public class DepthwiseConv2d: BaseConvolutionalLayer {
     
     outputSize = TensorSize(array: [columns, rows, inputSize.depth])
     
-    if biasEnabled {
+    if biasEnabled && biases.isEmpty {
       biases = Tensor([Tensor.Scalar](repeating: 0, count: inputSize.depth))
     }
   }

--- a/Sources/Neuron/Layers/Utilities/LayerGroup.swift
+++ b/Sources/Neuron/Layers/Utilities/LayerGroup.swift
@@ -36,6 +36,7 @@ public class BaseLayerGroup: BaseLayer, LayerGrouping {
       super.isTraining
     }
     set {
+      super.isTraining = newValue
       innerBlockSequential.isTraining = newValue
     }
   }

--- a/Tests/NeuronTests/LayerTests.swift
+++ b/Tests/NeuronTests/LayerTests.swift
@@ -1439,10 +1439,38 @@ final class LayerTests: XCTestCase {
     
     let importedWeights: [Tensor] = try importedSequential.exportWeights().fullFlatten()
     
+    XCTAssertEqual(expectedWeightsArray.count, importedWeights.count, "Weight tensor count mismatch")
+
     for (e, i) in zip(expectedWeightsArray, importedWeights) {
       XCTAssertTrue(e.isValueEqual(to: i, accuracy: 0.000001))
     }
-    
+
+    // Verify Dense biases are preserved through export/import
+    func collectDenseBiases(from seq: Sequential) -> [Tensor] {
+      var biases: [Tensor] = []
+      for layer in seq.layers {
+        if let dense = layer as? Dense, dense.biasEnabled {
+          biases.append(dense.biases)
+        }
+        if let group = layer as? BaseLayerGroup {
+          for inner in group.innerBlockSequential.layers {
+            if let dense = inner as? Dense, dense.biasEnabled {
+              biases.append(dense.biases)
+            }
+          }
+        }
+      }
+      return biases
+    }
+
+    let expectedBiases = collectDenseBiases(from: network)
+    let importedBiases = collectDenseBiases(from: importedSequential)
+
+    XCTAssertEqual(expectedBiases.count, importedBiases.count, "Dense bias count mismatch")
+
+    for (e, i) in zip(expectedBiases, importedBiases) {
+      XCTAssertTrue(e.isValueEqual(to: i, accuracy: 0.000001), "Dense biases differ after import")
+    }
   }
 
   func test_rexNet_isTraining_set() {
@@ -1457,13 +1485,15 @@ final class LayerTests: XCTestCase {
     let sequential = Sequential(rexNet)
     
     sequential.isTraining = true
-    
+
+    XCTAssertTrue(rexNet.isTraining, "RexNet isTraining getter should return true")
     rexNet.innerBlockSequential.layers.forEach { layer in
       XCTAssertTrue(layer.isTraining)
     }
-    
+
     sequential.isTraining = false
-    
+
+    XCTAssertFalse(rexNet.isTraining, "RexNet isTraining getter should return false after setting")
     rexNet.innerBlockSequential.layers.forEach { layer in
       XCTAssertFalse(layer.isTraining)
     }


### PR DESCRIPTION
## Changes

- **Dense.swift**: Only initialize biases if they're empty, preventing loss of imported bias values during model import
- **DepthwiseConv2d.swift**: Add check to only initialize biases if empty, consistent with Dense layer behavior
- **LayerGroup.swift**: Fix `isTraining` setter to properly propagate state to parent class
- **LayerTests.swift**: Add comprehensive tests to verify Dense biases are preserved through export/import cycles and that `isTraining` state is correctly maintained in layer groups

## Fixes

- Resolves issue where Dense layer biases were being lost during model import
- Ensures `isTraining` property correctly reflects state in BaseLayerGroup instances