### PR TITLE
docs: document public API surface

### DIFF
--- a/Sources/Neuron/Devices/Devices.swift
+++ b/Sources/Neuron/Devices/Devices.swift
@@ -27,9 +27,22 @@ public enum DeviceType: String, Codable {
 /// Conforming types provide hardware-specific implementations of neural network
 /// primitives such as convolution, activation, and pooling.
 public protocol Device {
+  /// The device type identifier (`.cpu` or `.gpu`).
   var type: DeviceType { get }
+  /// The Quality of Service class used for concurrent dispatch blocks on this device.
   var qosPriority: DispatchQoS.QoSClass { get set }
   
+  /// Computes a transposed 2D convolution directly into `result` using raw pointer storage.
+  ///
+  /// - Parameters:
+  ///   - signal: Pointer to the input feature-map data.
+  ///   - filter: Pointer to the transposed-convolution kernel data.
+  ///   - result: Pointer to the output buffer where results are written.
+  ///   - strides: Row/column stride of the transposed convolution.
+  ///   - padding: Padding mode applied to the operation.
+  ///   - filterSize: Kernel shape as `(rows, columns)`.
+  ///   - inputSize: Input spatial shape as `(rows, columns)`.
+  ///   - batchCount: Number of batches to process.
   func transConv2d(signal: TensorStorage.Pointer,
                           filter: TensorStorage.Pointer,
                           result: TensorStorage.Pointer,
@@ -38,7 +51,18 @@ public protocol Device {
                           filterSize: (rows: Int, columns: Int),
                           inputSize: (rows: Int, columns: Int),
                           batchCount: Int)
-  
+
+  /// Computes a 2D convolution directly into `result` using raw pointer storage.
+  ///
+  /// - Parameters:
+  ///   - signal: Pointer to the input feature-map data.
+  ///   - filter: Pointer to the convolution kernel data.
+  ///   - result: Pointer to the output buffer where results are written.
+  ///   - strides: Row/column stride of the convolution.
+  ///   - padding: Padding mode applied to the operation.
+  ///   - filterSize: Kernel shape as `(rows, columns)`.
+  ///   - inputSize: Input spatial shape as `(rows, columns)`.
+  ///   - batchCount: Number of batches to process.
   func conv2d(signal: TensorStorage.Pointer,
               filter: TensorStorage.Pointer,
               result: TensorStorage.Pointer,

--- a/Sources/Neuron/Export/ExportHelper.swift
+++ b/Sources/Neuron/Export/ExportHelper.swift
@@ -12,7 +12,10 @@ public struct ExportHelper: ModelBuilder {
   
 /// Defines supported file extensions for exported model files.
   public enum FileExtensions: String {
-    case smodel, stokens
+    /// File extension used for serialized network model files.
+    case smodel
+    /// File extension used for serialized tokenizer/vectorizer files.
+    case stokens
   }
   
   /// Accepts an array of T generics and returns the array as a CSV url that was saved to disk

--- a/Sources/Neuron/Helpers/WelfordVariance.swift
+++ b/Sources/Neuron/Helpers/WelfordVariance.swift
@@ -17,6 +17,7 @@ public final class WelfordVariance {
   @Atomic public private(set) var means: [Tensor.Value] = []
   /// Per-depth-slice M2 accumulators stored as flat arrays
   @Atomic public private(set) var m2s: [Tensor.Value] = []
+  /// The number of tensor samples incorporated into the running statistics so far.
   @Atomic public private(set) var iterations: Int = 0
   
   private var inputSize: TensorSize = .init(array: [])

--- a/Sources/Neuron/Layers/Activations/GeLu.swift
+++ b/Sources/Neuron/Layers/Activations/GeLu.swift
@@ -24,6 +24,10 @@ public final class GeLu: BaseActivationLayer {
          linkId
   }
   
+  /// Decodes a GeLU layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience public required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let linkId = try container.decodeIfPresent(String.self, forKey: .linkId) ?? UUID().uuidString

--- a/Sources/Neuron/Layers/Activations/LeakyReLu.swift
+++ b/Sources/Neuron/Layers/Activations/LeakyReLu.swift
@@ -30,6 +30,10 @@ public final class LeakyReLu: BaseActivationLayer {
          linkId
   }
   
+  /// Decodes a LeakyReLU layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience public required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let limit = try container.decodeIfPresent(Tensor.Scalar.self, forKey: .limit) ?? 0.01

--- a/Sources/Neuron/Layers/Activations/Mish.swift
+++ b/Sources/Neuron/Layers/Activations/Mish.swift
@@ -35,6 +35,10 @@ public final class Mish: BaseActivationLayer {
     case inputSize, type, linkId
   }
   
+  /// Decodes a Mish activation layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience public required init(from decoder: Decoder) throws {
     self.init()
     let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/Neuron/Layers/Activations/ReLu.swift
+++ b/Sources/Neuron/Layers/Activations/ReLu.swift
@@ -26,6 +26,10 @@ public final class ReLu: BaseActivationLayer {
                encodingType: .relu)
   }
   
+  /// Decodes a ReLU layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience required public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let linkId = try container.decodeIfPresent(String.self, forKey: .linkId) ?? UUID().uuidString

--- a/Sources/Neuron/Layers/Activations/SeLu.swift
+++ b/Sources/Neuron/Layers/Activations/SeLu.swift
@@ -26,6 +26,10 @@ public final class SeLu: BaseActivationLayer {
                encodingType: .selu)
   }
   
+  /// Decodes a SeLU layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience required public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let linkId = try container.decodeIfPresent(String.self, forKey: .linkId) ?? UUID().uuidString

--- a/Sources/Neuron/Layers/Activations/Sigmoid.swift
+++ b/Sources/Neuron/Layers/Activations/Sigmoid.swift
@@ -26,6 +26,10 @@ public final class Sigmoid: BaseActivationLayer {
          linkId
   }
   
+  /// Decodes a Sigmoid layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience required public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let linkId = try container.decodeIfPresent(String.self, forKey: .linkId) ?? UUID().uuidString

--- a/Sources/Neuron/Layers/Activations/Softmax.swift
+++ b/Sources/Neuron/Layers/Activations/Softmax.swift
@@ -17,6 +17,10 @@ public final class Softmax: BaseActivationLayer {
          linkId
   }
   
+  /// Decodes a Softmax layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience required public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let linkId = try container.decodeIfPresent(String.self, forKey: .linkId) ?? UUID().uuidString

--- a/Sources/Neuron/Layers/Activations/Swish.swift
+++ b/Sources/Neuron/Layers/Activations/Swish.swift
@@ -27,6 +27,10 @@ public final class Swish: BaseActivationLayer {
          linkId
   }
   
+  /// Decodes a Swish activation layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience required public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let linkId = try container.decodeIfPresent(String.self, forKey: .linkId) ?? UUID().uuidString

--- a/Sources/Neuron/Layers/Activations/Tanh.swift
+++ b/Sources/Neuron/Layers/Activations/Tanh.swift
@@ -26,6 +26,10 @@ public final class Tanh: BaseActivationLayer {
          linkId
   }
   
+  /// Decodes a Tanh activation layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience required public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let linkId = try container.decodeIfPresent(String.self, forKey: .linkId) ?? UUID().uuidString

--- a/Sources/Neuron/Layers/Add.swift
+++ b/Sources/Neuron/Layers/Add.swift
@@ -33,6 +33,10 @@ public final class Add: ArithmeticLayer {
                linkTo: linkTo)
   }
 
+  /// Decodes an Add layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   required public init(from decoder: Decoder) throws {
     try super.init(from: decoder)
   }

--- a/Sources/Neuron/Layers/AvgPool.swift
+++ b/Sources/Neuron/Layers/AvgPool.swift
@@ -31,6 +31,10 @@ public final class AvgPool: BaseLayer {
          linkId
   }
   
+  /// Decodes an AvgPool layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience public required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let linkId = try container.decodeIfPresent(String.self, forKey: .linkId) ?? UUID().uuidString

--- a/Sources/Neuron/Layers/BatchNormalize.swift
+++ b/Sources/Neuron/Layers/BatchNormalize.swift
@@ -122,6 +122,10 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
     case gamma, beta, momentum, movingMean, movingVariance, inputSize, linkId
   }
 
+  /// Decodes a BatchNormalize layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience public required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let gamma = try container.decodeIfPresent([Tensor.Scalar].self, forKey: .gamma) ?? []

--- a/Sources/Neuron/Layers/Dense.swift
+++ b/Sources/Neuron/Layers/Dense.swift
@@ -51,6 +51,10 @@ public final class Dense: BaseLayer {
          linkId
   }
   
+  /// Decodes a Dense layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience public required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let outputSize = try container.decodeIfPresent(TensorSize.self, forKey: .outputSize) ?? TensorSize(array: [])

--- a/Sources/Neuron/Layers/DepthwiseConv2d.swift
+++ b/Sources/Neuron/Layers/DepthwiseConv2d.swift
@@ -100,6 +100,10 @@ public class DepthwiseConv2d: BaseConvolutionalLayer {
          linkId
   }
   
+  /// Decodes a DepthwiseConv2d layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   required convenience public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let inputSize = try container.decodeIfPresent(TensorSize.self, forKey: .inputSize) ?? TensorSize(array: [])

--- a/Sources/Neuron/Layers/Divide.swift
+++ b/Sources/Neuron/Layers/Divide.swift
@@ -35,6 +35,10 @@ public final class Divide: ArithmeticLayer {
                linkTo: linkTo)
   }
 
+  /// Decodes a Divide layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   required public init(from decoder: Decoder) throws {
     try super.init(from: decoder)
   }

--- a/Sources/Neuron/Layers/Dropout.swift
+++ b/Sources/Neuron/Layers/Dropout.swift
@@ -44,6 +44,10 @@ public final class Dropout: BaseLayer {
          linkId
   }
   
+  /// Decodes a Dropout layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience public required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let linkId = try container.decodeIfPresent(String.self, forKey: .linkId) ?? UUID().uuidString

--- a/Sources/Neuron/Layers/Embedding/Embedding.swift
+++ b/Sources/Neuron/Layers/Embedding/Embedding.swift
@@ -60,6 +60,10 @@ public final class Embedding: BaseLayer {
          linkId
   }
   
+  /// Decodes an Embedding layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience required public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 

--- a/Sources/Neuron/Layers/Flatten.swift
+++ b/Sources/Neuron/Layers/Flatten.swift
@@ -30,12 +30,16 @@ public final class Flatten: BaseLayer {
     outputSize = TensorSize(array: [total, 1, 1])
   }
   
+  /// Decodes a Flatten layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience public required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let linkId = try container.decodeIfPresent(String.self, forKey: .linkId) ?? UUID().uuidString
     self.init(linkId: linkId)
     self.inputSize = try container.decodeIfPresent(TensorSize.self, forKey: .inputSize) ?? TensorSize(array: [])
-    
+
     let total = inputSize.columns * inputSize.rows * inputSize.depth
     self.outputSize = TensorSize(array: [total, 1, 1])
   }

--- a/Sources/Neuron/Layers/GlobalAveragePool.swift
+++ b/Sources/Neuron/Layers/GlobalAveragePool.swift
@@ -28,6 +28,10 @@ public final class GlobalAvgPool: BaseLayer {
     outputSize = .init(rows: 1, columns: inputSize.depth, depth: 1)
   }
   
+  /// Decodes a GlobalAvgPool layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience public required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let linkId = try container.decodeIfPresent(String.self, forKey: .linkId) ?? UUID().uuidString

--- a/Sources/Neuron/Layers/InstanceNormalize.swift
+++ b/Sources/Neuron/Layers/InstanceNormalize.swift
@@ -59,6 +59,10 @@ public final class InstanceNormalize: BaseLayer {
     setupTrainables()
   }
   
+  /// Decodes an InstanceNormalize layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience public required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let gamma = try container.decodeIfPresent(Tensor.self, forKey: .gamma) ?? .init()

--- a/Sources/Neuron/Layers/LSTM/LSTM.swift
+++ b/Sources/Neuron/Layers/LSTM/LSTM.swift
@@ -196,6 +196,10 @@ public final class LSTM: BaseLayer {
          linkId
   }
   
+  /// Decodes an LSTM layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience required public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let hiddenUnits = try container.decodeIfPresent(Int.self, forKey: .hiddenUnits) ?? 0

--- a/Sources/Neuron/Layers/Layer.swift
+++ b/Sources/Neuron/Layers/Layer.swift
@@ -164,6 +164,14 @@ open class ArithmeticLayer: BaseLayer {
     case inputSize, type, linkTo, linkId, inverse
   }
   
+  /// Applies the arithmetic operation to two input tensors.
+  ///
+  /// Subclasses must override this method to provide the actual element-wise operation.
+  ///
+  /// - Parameters:
+  ///   - input: The primary input tensor.
+  ///   - other: The secondary input tensor (from the linked layer).
+  /// - Returns: The result of applying the arithmetic operation.
   open func function(input: Tensor, other: Tensor) -> Tensor {
     fatalError("override in subclass")
   }
@@ -177,6 +185,10 @@ open class ArithmeticLayer: BaseLayer {
     }
   }
   
+  /// Decodes an ArithmeticLayer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   required public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     self.linkTo = try container.decodeIfPresent(String.self, forKey: .linkTo) ?? ""
@@ -323,11 +335,15 @@ open class BaseLayer: Layer {
     forward(tensor: tensor, context: context)
   }
   
+  /// Not intended for direct use — concrete layer subclasses must override to implement their own deserialization.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: Always produces a default empty layer; subclasses should override.
   required convenience public init(from decoder: Decoder) throws {
     // override
     self.init(encodingType: .none)
   }
-  
+
   /// Encodes layer configuration for persistence.
   ///
   /// Subclasses should override and encode their own fields.
@@ -522,6 +538,10 @@ open class BaseConvolutionalLayer: BaseLayer, ConvolutionalLayer {
     }
   }
   
+  /// Not intended for direct use — concrete convolutional layer subclasses must override.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: Always produces a default empty layer; subclasses should override.
   required convenience public init(from decoder: Decoder) throws {
     // override
     self.init(filterCount: 0, encodingType: .none)
@@ -608,6 +628,10 @@ open class BaseActivationLayer: BaseLayer, ActivationLayer {
     self.usesOptimizer = false
   }
   
+  /// Not intended for direct use — concrete activation layer subclasses must override.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: Always produces a default empty activation layer; subclasses should override.
   required convenience public init(from decoder: Decoder) throws {
     self.init(inputSize: .init(),
               type: .none,
@@ -679,6 +703,9 @@ open class BaseThreadBatchingLayer: BaseLayer {
     }
   }
 
+  /// Whether the layer should accumulate batch statistics during the forward pass.
+  ///
+  /// Returns `true` by default when the layer is in training mode.
   open var shouldPerformBatching: Bool {
     isTraining
   }

--- a/Sources/Neuron/Layers/LayerNormalize.swift
+++ b/Sources/Neuron/Layers/LayerNormalize.swift
@@ -63,6 +63,10 @@ public final class LayerNormalize: BaseLayer {
     setupTrainables()
   }
   
+  /// Decodes a LayerNormalize layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience public required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let gamma = try container.decodeIfPresent(Tensor.self, forKey: .gamma) ?? .init()

--- a/Sources/Neuron/Layers/MaxPool.swift
+++ b/Sources/Neuron/Layers/MaxPool.swift
@@ -40,6 +40,10 @@ public final class MaxPool: BaseLayer {
          linkId
   }
   
+  /// Decodes a MaxPool layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience public required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let linkId = try container.decodeIfPresent(String.self, forKey: .linkId) ?? UUID().uuidString

--- a/Sources/Neuron/Layers/Multiply.swift
+++ b/Sources/Neuron/Layers/Multiply.swift
@@ -26,6 +26,10 @@ public final class Multiply: ArithmeticLayer {
                linkTo: linkTo)
   }
 
+  /// Decodes a Multiply layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   required public init(from decoder: Decoder) throws {
     try super.init(from: decoder)
   }

--- a/Sources/Neuron/Layers/ResNet.swift
+++ b/Sources/Neuron/Layers/ResNet.swift
@@ -150,12 +150,16 @@ public final class ResNet: BaseLayerGroup {
     onBatchSizeSet()
   }
   
+  /// Decodes a ResNet block from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience public required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let filterCount = try container.decodeIfPresent(Int.self, forKey: .filterCount) ?? 64
     let stride = try container.decodeIfPresent(Int.self, forKey: .stride) ?? 1
     let linkId = try container.decodeIfPresent(String.self, forKey: .linkId) ?? UUID().uuidString
-    
+
     self.init(filterCount: filterCount, stride: stride, linkId: linkId)
     
     let innerBlockSequential = try container.decodeIfPresent(Sequential.self, forKey: .innerBlockSequential) ?? Sequential()

--- a/Sources/Neuron/Layers/Reshape.swift
+++ b/Sources/Neuron/Layers/Reshape.swift
@@ -36,6 +36,10 @@ public final class Reshape: BaseLayer {
          linkId
   }
   
+  /// Decodes a Reshape layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience public required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let linkId = try container.decodeIfPresent(String.self, forKey: .linkId) ?? UUID().uuidString

--- a/Sources/Neuron/Layers/RexNet.swift
+++ b/Sources/Neuron/Layers/RexNet.swift
@@ -136,6 +136,10 @@ public final class RexNet: BaseLayerGroup {
     outputSize = innerBlockSequential.layers.last?.outputSize ?? inputSize
   }
   
+  /// Decodes a RexNet block from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience public required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let linkId = try container.decodeIfPresent(String.self, forKey: .linkId) ?? UUID().uuidString

--- a/Sources/Neuron/Layers/Subtract.swift
+++ b/Sources/Neuron/Layers/Subtract.swift
@@ -32,6 +32,10 @@ public final class Subtract: ArithmeticLayer {
                linkTo: linkTo)
   }
 
+  /// Decodes a Subtract layer from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   required public init(from decoder: Decoder) throws {
     try super.init(from: decoder)
   }

--- a/Sources/Neuron/Layers/Utilities/LayerGroup.swift
+++ b/Sources/Neuron/Layers/Utilities/LayerGroup.swift
@@ -92,6 +92,10 @@ public class BaseLayerGroup: BaseLayer, LayerGrouping {
                encodingType: encodingType)
   }
   
+  /// Not supported on `BaseLayerGroup` — subclasses must override with their own serialization logic.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: Always triggers a `fatalError`; implement in concrete subclasses.
   required convenience public init(from decoder: Decoder) throws {
     fatalError("init(from:) has not been implemented")
   }

--- a/Sources/Neuron/Models/Classifier.swift
+++ b/Sources/Neuron/Models/Classifier.swift
@@ -23,8 +23,9 @@ public class Classifier {
 /// An optional closure called at the completion of each training epoch.
   public var onEpochCompleted: (() -> ())? = nil
   
+  /// The optimizer used to update the model's weights during training.
   public private(set) var optimizer: Optimizer
-  
+
   /// Creates a classifier training wrapper around an optimizer/trainable pair.
   ///
   /// - Parameters:

--- a/Sources/Neuron/Models/GAN.swift
+++ b/Sources/Neuron/Models/GAN.swift
@@ -28,8 +28,11 @@ open class GAN {
   public var validateGenerator: ((_ output: Tensor) -> ())? = nil
   /// An optional closure called when training has fully completed.
   public var onCompleted: (() -> ())? = nil
+  /// The loss function used to evaluate generator and discriminator performance.
   public private(set) var lossFunction: LossFunction = .minimaxBinaryCrossEntropy
+  /// The label value assigned to generated (fake) samples during discriminator training.
   public private(set) var fakeLabel: Tensor.Scalar = 0
+  /// The label value assigned to real samples during discriminator training.
   public private(set) var realLabel: Tensor.Scalar = 1
   /// The number of epochs for which the GAN will be trained.
   public var epochs: Int

--- a/Sources/Neuron/Optimizers/Optimizer.swift
+++ b/Sources/Neuron/Optimizers/Optimizer.swift
@@ -13,20 +13,34 @@ import NumSwift
 /// Conforming types manage the training loop, gradient computation, weight updates,
 /// and optional augmentation or metrics reporting.
 public protocol Optimizer: AnyObject {
+  /// A tuple containing weight and bias gradient tensors for a single layer.
   typealias Gradient = (weights: Tensor, biases: Tensor)
+  /// A tuple containing per-batch outputs, accumulated gradients, scalar loss, and accuracy.
   typealias Output = (outputs: [Tensor], gradients: Tensor.Gradient, loss: Tensor.Scalar, accuracy: Tensor.Scalar)
-  
+
+  /// The trainable network model whose parameters this optimizer manages.
   var trainable: Trainable { get set }
+  /// The current learning rate, taking into account any active decay or warmup schedule.
   var learningRate: Tensor.Scalar { get }
+  /// Indicates whether the optimizer is in training mode.
   var isTraining: Bool { get set }
+  /// The compute device used for forward and backward operations.
   var device: Device { get }
+  /// The compute device type; setting this updates the shared `DeviceManager`.
   var deviceType: DeviceType { get set }
+  /// An optional reporter for gathering training metrics such as loss, accuracy, and timing.
   var metricsReporter: MetricsReporter? { get set }
+  /// An optional upper bound for weight clipping applied after each parameter update.
   var weightClip: Tensor.Scalar? { get set }
+  /// An optional global gradient norm clip threshold applied before parameter updates.
   var gradientClip: Tensor.Scalar? { get set }
+  /// The accumulator that aggregates per-sample gradients across a mini-batch.
   var gradientAccumulator: GradientAccumulator { get }
+  /// An optional learning rate scheduler that applies warmup and/or decay.
   var learningRateScheduler: LearningRateScheduling? { get set }
+  /// The number of samples per optimization step.
   var batchSize: Int { get }
+  /// An optional augmenter applied to input data during training.
   var augmenter: Augmenter? { get set }
 
   /// Runs inference via call syntax.
@@ -66,6 +80,9 @@ public protocol Optimizer: AnyObject {
   /// - Returns: Prediction tensors.
   func predict(_ data: [Tensor]) -> [Tensor]
   
+  /// Called at the end of each training epoch; used to update learning rate schedulers and other epoch-level state.
+  ///
+  /// - Parameter epoch: The zero-based epoch index that just completed.
   func onEpochEnd(epoch: Int)
 }
 
@@ -356,6 +373,9 @@ open class BaseOptimizer: Optimizer {
     }
   }
   
+  /// Called at the end of each training epoch to advance the learning rate scheduler.
+  ///
+  /// - Parameter epoch: The index of the epoch that just completed.
   open func onEpochEnd(epoch: Int) {
     learningRateScheduler?.step(type: .epoch)
   }

--- a/Sources/Neuron/Optimizers/WarmupFunction/WarmupFunction.swift
+++ b/Sources/Neuron/Optimizers/WarmupFunction/WarmupFunction.swift
@@ -46,11 +46,16 @@ open class BaseWarmupFunction: WarmupFunction {
     self.warmupSteps = warmupSteps
   }
   
+  /// Resets the warmup schedule to its initial state, zeroing the learning rate and step counter.
   open func reset() {
     warmedLearningRate = 0
     globalSteps = 0
   }
-  
+
+  /// Advances the warmup schedule by one step.
+  ///
+  /// Subclasses should override this method to update `warmedLearningRate` using their
+  /// specific warmup formula, then call `super.step()` to increment `globalSteps`.
   open func step() {
     // override and apply function here
     globalSteps += 1

--- a/Sources/Neuron/Tensor/Tensor.swift
+++ b/Sources/Neuron/Tensor/Tensor.swift
@@ -51,6 +51,8 @@ public class Tensor: Equatable, Codable {
 /// A unique identifier type for `Tensor` instances.
   public typealias ID = UInt64
   
+  /// A dictionary mapping tensor IDs to their corresponding branch gradient tensors,
+  /// used to accumulate gradients from multiple downstream consumers of this tensor.
   public private(set) var branchGradients: [Tensor.ID: Tensor] = [:]
   
   /// Gradient object returned from `gradient` calculation on the Tensor. Contains gradients w.r.t to the `input`, w.r.t to the `weights`, and w.r.t to the `biases`
@@ -188,6 +190,11 @@ public class Tensor: Equatable, Codable {
     self.context = TensorContext()
   }
 
+  /// Decodes a `Tensor` from a serialized model, supporting both the legacy nested-array format
+  /// and the current flat `TensorStorage` format.
+  ///
+  /// - Parameter decoder: Decoder used to read tensor data.
+  /// - Throws: An error if required values cannot be decoded.
   required public init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     self.label = try container.decode(String.self, forKey: .label)
@@ -985,11 +992,16 @@ extension Array where Element == Tensor {
 
 public extension Tensor.Gradient {
   
-  func l2NomalizeWeightsAndBiases() { 
+  /// Normalizes all weight and bias gradient tensors in place to unit L2 norm.
+  func l2NomalizeWeightsAndBiases() {
     weights.forEach { $0.l2Normalize() }
     biases.forEach { $0.l2Normalize() }
   }
-  
+
+  /// Computes the global L2 norm across all weight and bias gradients.
+  ///
+  /// - Parameter metrics: Optional reporter that records the global gradient norm.
+  /// - Returns: The combined L2 norm of all weight and bias gradients.
   @discardableResult
   func calculateL2Norm(metrics: MetricsReporter? = nil) -> Tensor.Scalar {
     let allWeights = weights.reduce(Tensor()) { partialResult, new in
@@ -1009,6 +1021,12 @@ public extension Tensor.Gradient {
     return globalNorm
   }
   
+  /// Clips all weight and bias gradients by the global L2 norm, scaling them if the norm exceeds `value`.
+  ///
+  /// - Parameters:
+  ///   - value: The maximum allowed global gradient norm. Defaults to `1.0`.
+  ///   - metrics: Optional reporter that records the global norm and scaling factor applied.
+  /// - Returns: A new `Tensor.Gradient` with clipped weight and bias gradients.
   func gradientL2NormClip(_ value: Tensor.Scalar = 1.0, metrics: MetricsReporter? = nil) -> Tensor.Gradient {
     let globalNorm = calculateL2Norm(metrics: metrics)
     
@@ -1028,6 +1046,13 @@ public extension Tensor.Gradient {
     )
   }
   
+  /// Applies a pairwise binary operation to the input, weight, and bias arrays of two gradients.
+  ///
+  /// - Parameters:
+  ///   - lhs: The left-hand `Tensor.Gradient`.
+  ///   - rhs: The right-hand `Tensor.Gradient`.
+  ///   - block: A closure applied element-wise to each gradient component array.
+  /// - Returns: A new `Tensor.Gradient` with `block` applied to each component.
   static func applyMultiple(lhs: Tensor.Gradient,
                             rhs: Tensor.Gradient,
                             block: (_ lhs: [Tensor], _ rhs: [Tensor]) -> [Tensor]) -> Tensor.Gradient {
@@ -1037,6 +1062,13 @@ public extension Tensor.Gradient {
     return Tensor.Gradient(input: input, weights: weight, biases: bias)
   }
   
+  /// Applies a scalar operation to each gradient component array.
+  ///
+  /// - Parameters:
+  ///   - lhs: The `Tensor.Gradient` to scale.
+  ///   - rhs: The scalar to apply.
+  ///   - block: A closure combining each gradient component array with `rhs`.
+  /// - Returns: A new `Tensor.Gradient` with `block` applied to each component.
   static func applyScalar(lhs: Tensor.Gradient,
                           rhs: Tensor.Scalar,
                           block: (_ lhs: [Tensor], _ rhs: Tensor.Scalar) -> [Tensor]) -> Tensor.Gradient {
@@ -1046,34 +1078,42 @@ public extension Tensor.Gradient {
     return Tensor.Gradient(input: input, weights: weight, biases: bias)
   }
   
+  /// Divides all gradient components element-wise by the corresponding components of `rhs`.
   static func /(lhs: Tensor.Gradient, rhs: Tensor.Gradient) -> Tensor.Gradient {
     applyMultiple(lhs: lhs, rhs: rhs) { lhs, rhs in lhs / rhs }
   }
-  
+
+  /// Multiplies all gradient components element-wise by the corresponding components of `rhs`.
   static func *(lhs: Tensor.Gradient, rhs: Tensor.Gradient) -> Tensor.Gradient {
     applyMultiple(lhs: lhs, rhs: rhs) { lhs, rhs in lhs * rhs }
   }
-  
+
+  /// Subtracts all gradient components element-wise from the corresponding components of `rhs`.
   static func -(lhs: Tensor.Gradient, rhs: Tensor.Gradient) -> Tensor.Gradient {
     applyMultiple(lhs: lhs, rhs: rhs) { lhs, rhs in lhs - rhs }
   }
-  
+
+  /// Adds all gradient components element-wise to the corresponding components of `rhs`.
   static func +(lhs: Tensor.Gradient, rhs: Tensor.Gradient) -> Tensor.Gradient {
     applyMultiple(lhs: lhs, rhs: rhs) { lhs, rhs in lhs + rhs }
   }
-  
+
+  /// Adds a scalar to all gradient component tensors.
   static func +(lhs: Tensor.Gradient, rhs: Tensor.Scalar) -> Tensor.Gradient {
     applyScalar(lhs: lhs, rhs: rhs) { lhs, rhs in lhs + rhs }
   }
-  
+
+  /// Subtracts a scalar from all gradient component tensors.
   static func -(lhs: Tensor.Gradient, rhs: Tensor.Scalar) -> Tensor.Gradient {
     applyScalar(lhs: lhs, rhs: rhs) { lhs, rhs in lhs - rhs }
   }
-  
+
+  /// Divides all gradient component tensors by a scalar.
   static func /(lhs: Tensor.Gradient, rhs: Tensor.Scalar) -> Tensor.Gradient {
     applyScalar(lhs: lhs, rhs: rhs) { lhs, rhs in lhs / rhs }
   }
-  
+
+  /// Multiplies all gradient component tensors by a scalar.
   static func *(lhs: Tensor.Gradient, rhs: Tensor.Scalar) -> Tensor.Gradient {
     applyScalar(lhs: lhs, rhs: rhs) { lhs, rhs in lhs * rhs }
   }
@@ -1082,6 +1122,12 @@ public extension Tensor.Gradient {
 // MARK: - Static Factory Methods
 
 public extension Tensor {
+  /// Creates a tensor whose elements are drawn uniformly at random from `range`.
+  ///
+  /// - Parameters:
+  ///   - range: The closed range of scalar values to sample from. Defaults to `0...1`.
+  ///   - size: The shape of the tensor to create.
+  /// - Returns: A new `Tensor` with random values in the specified range.
   static func fillRandom(in range: ClosedRange<Tensor.Scalar> = 0...1, size: TensorSize) -> Tensor {
     let count = size.columns * size.rows * size.depth
     let s = TensorStorage.create(count: count)
@@ -1093,6 +1139,12 @@ public extension Tensor {
     return Tensor(storage: s, size: size)
   }
   
+  /// Creates a tensor filled with a constant scalar value.
+  ///
+  /// - Parameters:
+  ///   - value: The scalar value to fill every element with.
+  ///   - size: The shape of the tensor to create.
+  /// - Returns: A new `Tensor` where every element equals `value`.
   static func fillWith(value: Tensor.Scalar, size: TensorSize) -> Tensor {
     let s = TensorStorage.create(repeating: value, count: size.columns * size.rows * size.depth)
     return Tensor(storage: s, size: size)

--- a/Sources/Neuron/Tensor/TensorMath.swift
+++ b/Sources/Neuron/Tensor/TensorMath.swift
@@ -9,6 +9,7 @@ import Foundation
 import NumSwift
 
 public extension Float {
+  /// A small constant added to denominators and square-roots for numerical stability.
   static var stabilityFactor: Self {
     1e-12
   }
@@ -16,6 +17,8 @@ public extension Float {
 
 #if arch(arm64)
 public extension Float16 {
+  /// A small constant added to denominators and square-roots for numerical stability.
+  /// Uses a larger value than `Float` to account for reduced precision in Float16.
   static var stabilityFactor: Self {
     1e-4
   }
@@ -23,6 +26,8 @@ public extension Float16 {
 #endif
 
 public extension Tensor {
+  /// A closure type that receives a pointer to a contiguous block of scalars and its count,
+  /// and returns a single reduced scalar result (e.g., sum, mean, or max).
   typealias PointerMathBlock = (_ ptr: TensorStorage.Pointer, _ count: Int) -> Scalar
   
   /*

--- a/Sources/Neuron/Tensor/TensorSize.swift
+++ b/Sources/Neuron/Tensor/TensorSize.swift
@@ -105,6 +105,7 @@ public struct TensorSize: Codable, Equatable, Comparable {
 }
 
 public extension Array where Element == Int {
+  /// Converts an integer array into a `TensorSize` using `[columns, rows, depth]` ordering.
   var tensorSize: TensorSize {
     return TensorSize(array: self)
   }

--- a/Sources/Neuron/Tensor/TensorStorage+Arithmetic.swift
+++ b/Sources/Neuron/Tensor/TensorStorage+Arithmetic.swift
@@ -12,6 +12,7 @@ import NumSwift
 
 public extension TensorStorage {
 
+  /// Returns element-wise sum of two storages, operating on the shorter count.
   static func + (lhs: TensorStorage, rhs: TensorStorage) -> TensorStorage {
     let count = Swift.min(lhs.count, rhs.count)
     let result = TensorStorage.create(count: count)
@@ -19,6 +20,7 @@ public extension TensorStorage {
     return result
   }
 
+  /// Returns element-wise difference of two storages, operating on the shorter count.
   static func - (lhs: TensorStorage, rhs: TensorStorage) -> TensorStorage {
     let count = Swift.min(lhs.count, rhs.count)
     let result = TensorStorage.create(count: count)
@@ -26,6 +28,7 @@ public extension TensorStorage {
     return result
   }
 
+  /// Returns element-wise product of two storages, operating on the shorter count.
   static func * (lhs: TensorStorage, rhs: TensorStorage) -> TensorStorage {
     let count = Swift.min(lhs.count, rhs.count)
     let result = TensorStorage.create(count: count)
@@ -33,6 +36,7 @@ public extension TensorStorage {
     return result
   }
 
+  /// Returns element-wise quotient of two storages, operating on the shorter count.
   static func / (lhs: TensorStorage, rhs: TensorStorage) -> TensorStorage {
     let count = Swift.min(lhs.count, rhs.count)
     let result = TensorStorage.create(count: count)
@@ -45,24 +49,28 @@ public extension TensorStorage {
 
 public extension TensorStorage {
 
+  /// Returns a new storage with `rhs` added to every element.
   static func + (lhs: TensorStorage, rhs: Tensor.Scalar) -> TensorStorage {
     let result = TensorStorage.create(count: lhs.count)
     NumSwiftFlat.add(lhs.pointer, scalar: rhs, result: result.pointer, count: lhs.count)
     return result
   }
 
+  /// Returns a new storage with `rhs` subtracted from every element.
   static func - (lhs: TensorStorage, rhs: Tensor.Scalar) -> TensorStorage {
     let result = TensorStorage.create(count: lhs.count)
     NumSwiftFlat.sub(lhs.pointer, scalar: rhs, result: result.pointer, count: lhs.count)
     return result
   }
 
+  /// Returns a new storage with every element multiplied by `rhs`.
   static func * (lhs: TensorStorage, rhs: Tensor.Scalar) -> TensorStorage {
     let result = TensorStorage.create(count: lhs.count)
     NumSwiftFlat.mul(lhs.pointer, scalar: rhs, result: result.pointer, count: lhs.count)
     return result
   }
 
+  /// Returns a new storage with every element divided by `rhs`.
   static func / (lhs: TensorStorage, rhs: Tensor.Scalar) -> TensorStorage {
     let result = TensorStorage.create(count: lhs.count)
     NumSwiftFlat.div(lhs.pointer, scalar: rhs, result: result.pointer, count: lhs.count)
@@ -74,24 +82,28 @@ public extension TensorStorage {
 
 public extension TensorStorage {
 
+  /// Returns a new storage with every element multiplied by the scalar `lhs`.
   static func * (lhs: Tensor.Scalar, rhs: TensorStorage) -> TensorStorage {
     let result = TensorStorage.create(count: rhs.count)
     NumSwiftFlat.mul(rhs.pointer, scalar: lhs, result: result.pointer, count: rhs.count)
     return result
   }
 
+  /// Returns a new storage with `lhs` subtracted element-wise from each element in `rhs`.
   static func - (lhs: Tensor.Scalar, rhs: TensorStorage) -> TensorStorage {
     let result = TensorStorage.create(count: rhs.count)
     NumSwiftFlat.sub(scalar: lhs, rhs.pointer, result: result.pointer, count: rhs.count)
     return result
   }
 
+  /// Returns a new storage with `lhs` divided element-wise by each element in `rhs`.
   static func / (lhs: Tensor.Scalar, rhs: TensorStorage) -> TensorStorage {
     let result = TensorStorage.create(count: rhs.count)
     NumSwiftFlat.div(scalar: lhs, rhs.pointer, result: result.pointer, count: rhs.count)
     return result
   }
 
+  /// Returns a new storage with `lhs` added to every element.
   static func + (lhs: Tensor.Scalar, rhs: TensorStorage) -> TensorStorage {
     let result = TensorStorage.create(count: rhs.count)
     NumSwiftFlat.add(rhs.pointer, scalar: lhs, result: result.pointer, count: rhs.count)

--- a/Sources/Neuron/Tensor/TensorStorage.swift
+++ b/Sources/Neuron/Tensor/TensorStorage.swift
@@ -218,6 +218,10 @@ public class TensorStorage {
 
   // MARK: - Codable
 
+  /// Decodes tensor storage from a single-value JSON array.
+  ///
+  /// - Parameter decoder: The decoder to read scalar data from.
+  /// - Throws: An error if the array cannot be decoded.
   public required convenience init(from decoder: any Decoder) throws {
     let container = try decoder.singleValueContainer()
     let array = try container.decode([Tensor.Scalar].self)

--- a/Sources/Neuron/Tokenizers/Tokenizing.swift
+++ b/Sources/Neuron/Tokenizers/Tokenizing.swift
@@ -13,8 +13,21 @@ public typealias TokenizerCorpus = [String]
 
 /// A protocol that defines tokenization capabilities with support for encoding, decoding, and exporting trained models.
 public protocol Tokenizing: Exportable {
+  /// Trains the tokenizer on the given corpus, building the vocabulary and merge rules.
+  ///
+  /// - Parameter corpus: An array of text strings used to fit the tokenizer.
   func train(corpus: TokenizerCorpus)
+
+  /// Encodes a text string into a sequence of integer token IDs.
+  ///
+  /// - Parameter input: The string to encode.
+  /// - Returns: A sequence of integer token IDs.
   func encode(_ input: String) -> [Int]
+
+  /// Decodes a sequence of integer token IDs back into a text string.
+  ///
+  /// - Parameter ids: The integer token IDs to decode.
+  /// - Returns: The reconstructed text string.
   func decode(_ ids: [Int]) -> String
 }
 
@@ -88,6 +101,9 @@ open class BaseTokenizer: Tokenizing {
     try container.encode(targetVocabSize, forKey: .targetVocabSize)
   }
   
+  /// Trains the BPE tokenizer on the given text corpus, building a vocabulary up to `targetVocabSize`.
+  ///
+  /// - Parameter corpus: An array of text strings used to learn byte-pair merge rules.
   open func train(corpus: TokenizerCorpus) {
     let flatCorpus = corpus.joined(separator: " ")
     
@@ -138,8 +154,12 @@ open class BaseTokenizer: Tokenizing {
     }
   }
   
+  /// Encodes a text string into a sequence of token IDs using the learned BPE vocabulary.
+  ///
+  /// - Parameter text: The input string to encode.
+  /// - Returns: An array of integer token IDs corresponding to the input text.
   open func encode(_ text: String) -> [Int] {
-    
+
     var tokenIds: [Int] = []
     let words = text.components(separatedBy: " ")
     
@@ -181,6 +201,10 @@ open class BaseTokenizer: Tokenizing {
     return tokenIds
   }
   
+  /// Decodes a sequence of token IDs back into a human-readable string.
+  ///
+  /// - Parameter tokenIds: An array of integer token IDs to decode.
+  /// - Returns: The reconstructed string with end-of-word markers replaced by spaces.
   open func decode(_ tokenIds: [Int]) -> String {
     // Invert the vocab dictionary
     let idToToken = reverseVocab

--- a/Sources/Neuron/Trainable/Sequential.swift
+++ b/Sources/Neuron/Trainable/Sequential.swift
@@ -132,6 +132,10 @@ public final class Sequential: Trainable, Logger {
     self.layers = layers()
   }
   
+  /// Decodes a `Sequential` model from a serialized `.smodel` file.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   convenience public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     

--- a/Sources/Neuron/Trainable/Trainable.swift
+++ b/Sources/Neuron/Trainable/Trainable.swift
@@ -23,6 +23,7 @@ public protocol Trainable: AnyObject, Exportable, CustomDebugStringConvertible {
   /// Indicates if this particular network has its weights updated. Mainly used for Batch and Layer normalize. As they have different paths for training and not training.
   var isTraining: Bool { get set }
   
+  /// The compute device type used for inference and training.
   var deviceType: DeviceType { get set }
   
   /// The device to execute the ML ops and math ops on. Default: CPU()

--- a/Sources/Neuron/Utilities/Extensions+Numbers.swift
+++ b/Sources/Neuron/Utilities/Extensions+Numbers.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public extension Int {
+  /// Converts the integer to a `Tensor.Scalar` value (`Float` or `Float16` depending on build configuration).
   var asTensorScalar: Tensor.Scalar {
     Tensor.Scalar(self)
   }

--- a/Sources/Neuron/Utilities/Extensions+String.swift
+++ b/Sources/Neuron/Utilities/Extensions+String.swift
@@ -8,10 +8,18 @@
 import Foundation
 
 public extension String {
+  /// Returns the string's Unicode scalars as an array of single-character strings.
   var characters: [String] {
     map { String($0) }
   }
 
+  /// Pads the string to a minimum width by inserting `char` characters.
+  ///
+  /// - Parameters:
+  ///   - char: The fill character. Defaults to a space.
+  ///   - max: The minimum character width to achieve.
+  ///   - leftAlign: When `true`, appends characters to the right side; when `false`, prepends to the left.
+  /// - Returns: A new string padded to at least `max` characters.
   func fill(with char: Character = " ", max: Int, leftAlign: Bool = true) -> String {
     guard max - self.count > 0 else {
       return self

--- a/Sources/Neuron/Utilities/Vectorize.swift
+++ b/Sources/Neuron/Utilities/Vectorize.swift
@@ -29,6 +29,7 @@ public protocol Vectorizing: Exportable {
   typealias Vector = [Item: Int]
   typealias InverseVector = [Int: Item]
   
+  /// The last integer index assigned during vectorization.
   var lastKey: Int { get }
   /// Value that indicate starting of a vector
   var start: Int { get }
@@ -67,11 +68,13 @@ public protocol Vectorizing: Exportable {
 /// ex. Can take a string and apply a integer value to the word so that if it came up again
 /// it would return the same integer value for that word.
 public class Vectorizer: Vectorizing, Codable {
-/// The maximum index currently assigned, representing the next available index offset
-/// after reserving indices for start and end tokens.
+  /// The current full vector storage of every value passed in keyed by the `Item`.
   public private(set) var vector: Vector = [:]
+  /// The current full vector storage of every value passed in keyed by the `Index`.
   public private(set) var inverseVector: InverseVector = [:]
-  
+
+  /// The maximum index currently assigned, representing the next available index offset
+  /// after reserving indices for start and end tokens.
   public private(set) var lastKey: Int = 0
   
   /// Value that indicate starting of a vactor
@@ -102,6 +105,10 @@ public class Vectorizer: Vectorizing, Codable {
     case maxIndex
   }
   
+  /// Decodes a `Vectorizer` instance from a serialized model.
+  ///
+  /// - Parameter decoder: Decoder used during model loading.
+  /// - Throws: An error if required values cannot be decoded.
   public required init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     self.vector = try container.decode(Vector.self, forKey: .vector)


### PR DESCRIPTION
## Summary

- Comprehensive `///` documentation pass across **48 files** and **~340 lines** of new doc comments in `Sources/Neuron/`.
- Every `public`/`open` declaration that lacked a doc comment now has a one-line summary, `- Parameter:` blocks, `- Returns:` and `- Throws:` entries where applicable.
- No implementation code was modified — doc comments only. All signatures, logic, and behavior are unchanged.

## Modules / Files Documented

| Module | Files |
|--------|-------|
| **Tensor** | `Tensor.swift`, `TensorStorage.swift`, `TensorStorage+Arithmetic.swift`, `TensorMath.swift`, `TensorSize.swift` |
| **Layers – Activations** | `ReLu`, `LeakyReLu`, `GeLu`, `SeLu`, `Sigmoid`, `Softmax`, `Swish`, `Tanh`, `Mish` |
| **Layers – Core** | `Layer.swift` (BaseLayer, ArithmeticLayer, BaseThreadBatchingLayer), `Dense`, `DepthwiseConv2d`, `BatchNormalize`, `LayerNormalize`, `InstanceNormalize`, `MaxPool`, `AvgPool`, `GlobalAveragePool`, `Flatten`, `Reshape`, `Dropout`, `Embedding`, `LSTM`, `Add`, `Subtract`, `Multiply`, `Divide`, `ResNet`, `RexNet`, `LayerGroup` |
| **Optimizers** | `Optimizer.swift` (BaseOptimizer), `WarmupFunction` |
| **Models** | `Classifier.swift`, `GAN.swift` |
| **Trainable** | `Sequential.swift`, `Trainable.swift` |
| **Devices** | `Devices.swift` (Device protocol, CPU, GPU stubs) |
| **Tokenizers** | `Tokenizing.swift` (BaseTokenizer) |
| **Utilities** | `Extensions+Numbers.swift`, `Extensions+String.swift`, `Vectorize.swift`, `WelfordVariance.swift`, `ExportHelper.swift` |

## Test Plan

- [ ] `swift build` — changes are doc-only so should not affect compilation
- [ ] `CI=true swift test` — no behavior changed, all existing tests should pass
- [ ] Verify Swift DocC can generate documentation from the new comments

Note: `swift` toolchain was not available in the CI environment used for this branch; the changes are purely additive `///` comments with no impact on compiled output.

https://claude.ai/code/session_01GHKMWTeS8nerd3m3i1Nsv5

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHKMWTeS8nerd3m3i1Nsv5)_