### PR TITLE
docs: document public API surface

### DIFF
--- a/Sources/Neuron/Constants.swift
+++ b/Sources/Neuron/Constants.swift
@@ -9,12 +9,12 @@ import Foundation
 
 /// A namespace for global configuration constants used throughout the framework.
 public struct Constants {
-/// The default weight initializer type applied when initializing neural network layers.
+  /// The default weight initializer type applied when initializing neural network layers.
   ///
   /// Defaults to `.heNormal`, which is suitable for layers using ReLU activations.
   public static var defaultInitializer: InitializerType = .heNormal
-  
-/// The maximum number of worker threads to use for parallel operations.
+
+  /// The maximum number of worker threads to use for parallel operations.
   ///
   /// Determined at runtime by querying the number of performance CPU cores and rounding
   /// down to the nearest power of two to allow even work distribution across threads.

--- a/Sources/Neuron/Export/LayerModel.swift
+++ b/Sources/Neuron/Export/LayerModel.swift
@@ -19,7 +19,10 @@ public class LayerModel: Codable {
   
   /// Coding keys used for encoding and decoding the layer and its type discriminator.
   public enum CodingKeys: String, CodingKey {
-    case layer, type
+    /// Key for the encoded layer payload.
+    case layer
+    /// Key for the layer's `EncodingType` discriminator.
+    case type
   }
   
   /// Decodes a polymorphic layer wrapper by reading its `EncodingType`.

--- a/Sources/Neuron/Export/LayerModelConverter.swift
+++ b/Sources/Neuron/Export/LayerModelConverter.swift
@@ -11,9 +11,8 @@ import NumSwift
 /// A utility struct responsible for converting encoded layer data into concrete `Layer` instances.
 public struct LayerModelConverter {
   /// Coding keys used for decoding layer model data.
-  ///
-  /// - `layer`: The key corresponding to the encoded layer payload.
   public enum CodingKeys: String, CodingKey {
+    /// Key for the encoded layer payload.
     case layer
   }
   

--- a/Sources/Neuron/Initializers.swift
+++ b/Sources/Neuron/Initializers.swift
@@ -35,19 +35,25 @@ public enum InitializerType: Codable, Equatable {
 /// A structure that represents a weight initializer, encapsulating an initialization strategy
 /// and an optional Gaussian distribution for generating initial weight values.
 public struct Initializer {
-/// The type of initialization strategy used by this initializer.
+  /// The type of initialization strategy used by this initializer.
   public let type: InitializerType
   private var dist: Gaussian = Gaussian(std: 1, mean: 0)
   private var normal = NormalDistribution(mean: 0, deviation: 1)
-  
-/// Coding keys used for encoding and decoding the initializer type,
+
+  /// Coding keys used for encoding and decoding the initializer type,
   /// each mapping to a corresponding `InitializerType` value.
   public enum CodingKeys: String, CodingKey, CaseIterable {
+    /// Key for Xavier normal initialization.
     case xavierNormal
+    /// Key for Xavier uniform initialization.
     case xavierUniform
+    /// Key for He normal initialization.
     case heNormal
+    /// Key for He uniform initialization.
     case heUniform
+    /// Key for normal (Gaussian) initialization.
     case normal
+    /// Key for orthogonal initialization.
     case orthogonal
     
     var type: InitializerType {

--- a/Sources/Neuron/Layers/Activations/Activation.swift
+++ b/Sources/Neuron/Layers/Activations/Activation.swift
@@ -13,16 +13,27 @@ import Numerics
 /// Each case corresponds to a specific mathematical activation function
 /// that can be applied element-wise to a tensor during forward and backward passes.
 public enum Activation: Codable, Equatable {
+  /// Rectified Linear Unit: `max(0, x)`.
   case reLu
+  /// Logistic sigmoid: `1 / (1 + exp(-x))`.
   case sigmoid
+  /// Leaky ReLU with a configurable negative-slope `limit`.
   case leakyRelu(limit: Tensor.Scalar)
+  /// Swish self-gated activation: `x * sigmoid(x)`.
   case swish
+  /// Hyperbolic tangent activation.
   case tanh
+  /// Softmax normalization over a vector (requires a dedicated `Softmax` layer for full operation).
   case softmax
+  /// Scaled Exponential Linear Unit (SELU) with fixed scale and shift constants.
   case seLu
+  /// Gaussian Error Linear Unit (GELU) approximated via the error function.
   case geLu
+  /// Mish activation: `x * tanh(softplus(x))`. Uses a custom forward pass.
   case mish
+  /// Parametric ReLU with a learnable negative-slope parameter. Uses a custom forward pass.
   case prelu
+  /// Identity / no-op activation — passes input through unchanged.
   case none
   
   /// Returns the numeric activation identifier used by Metal kernels.

--- a/Sources/Neuron/Layers/Activations/GeLu.swift
+++ b/Sources/Neuron/Layers/Activations/GeLu.swift
@@ -11,6 +11,8 @@ import NumSwift
 /// Performs a GeLu activation.
 public final class GeLu: BaseActivationLayer {
   /// Creates a GeLU activation layer.
+  ///
+  /// - Parameter linkId: A stable identifier used to link this layer across serialization boundaries.
   public init(linkId: String = UUID().uuidString) {
     super.init(type: .geLu,
                linkId: linkId,

--- a/Sources/Neuron/Layers/AvgPool.swift
+++ b/Sources/Neuron/Layers/AvgPool.swift
@@ -11,8 +11,11 @@ import NumSwift
 public final class AvgPool: BaseLayer {
 
   private var kernelSize: TensorSize
-  /// Default initializer for max pooling.
-  /// - Parameter inputSize: Optional input size at this layer. If this is the first layer you will need to set this.
+  /// Default initializer for average pooling.
+  /// - Parameters:
+  ///   - inputSize: Optional input size at this layer. If this is the first layer you will need to set this.
+  ///   - kernelSize: The pooling window size in rows and columns. Defaults to `(rows: 2, columns: 2)`.
+  ///   - linkId: A unique string identifier for this layer link. Defaults to a new UUID string.
   public init(inputSize: TensorSize? = nil,
               kernelSize: (rows: Int, columns: Int) = (rows: 2, columns: 2),
               linkId: String = UUID().uuidString) {

--- a/Sources/Neuron/Layers/BatchNormalize.swift
+++ b/Sources/Neuron/Layers/BatchNormalize.swift
@@ -113,7 +113,20 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
 
   /// Coding keys used to encode and decode the batch normalization layer's parameters.
   public enum CodingKeys: String, CodingKey {
-    case gamma, beta, momentum, movingMean, movingVariance, inputSize, linkId
+    /// Key for the learnable gamma scale parameter.
+    case gamma
+    /// Key for the learnable beta shift parameter.
+    case beta
+    /// Key for the exponential averaging momentum.
+    case momentum
+    /// Key for the running mean used during inference.
+    case movingMean
+    /// Key for the running variance used during inference.
+    case movingVariance
+    /// Key for the layer's input size.
+    case inputSize
+    /// Key for the layer's stable link identifier.
+    case linkId
   }
 
   /// Decodes a BatchNormalize layer from a serialized model.

--- a/Sources/Neuron/Layers/Flatten.swift
+++ b/Sources/Neuron/Layers/Flatten.swift
@@ -11,7 +11,9 @@ import NumSwift
 /// Will take an inputSize of [M, N, K] and outputs [M * N * K, 1, 1]
 public final class Flatten: BaseLayer {
   /// Default initializer for Flatten layer.
-  /// - Parameter inputSize: Optional input size at this layer. If this is the first layer you will need to set this.
+  /// - Parameters:
+  ///   - inputSize: Optional input size at this layer. If this is the first layer you will need to set this.
+  ///   - linkId: A unique string identifier for this layer link. Defaults to a new UUID string.
   public init(inputSize: TensorSize? = nil,
               linkId: String = UUID().uuidString) {
     super.init(inputSize: inputSize,

--- a/Sources/Neuron/Layers/InstanceNormalize.swift
+++ b/Sources/Neuron/Layers/InstanceNormalize.swift
@@ -27,9 +27,18 @@ public final class InstanceNormalize: BaseLayer {
   /// The beta shift parameter used in layer normalization.
   public var beta: Tensor = .init()
 
-  /// Coding keys used for encoding and decoding the layer normalization layer.
+  /// Coding keys used for encoding and decoding the instance normalization layer.
   public enum CodingKeys: String, CodingKey {
-    case gamma, beta, epsilon, inputSize, linkId
+    /// Key for the learnable gamma scale parameter.
+    case gamma
+    /// Key for the learnable beta shift parameter.
+    case beta
+    /// Key for the epsilon stability term.
+    case epsilon
+    /// Key for the layer's input size.
+    case inputSize
+    /// Key for the layer's stable link identifier.
+    case linkId
   }
   
   /// Default initializer for layer normalization.

--- a/Sources/Neuron/Layers/Layer.swift
+++ b/Sources/Neuron/Layers/Layer.swift
@@ -15,37 +15,68 @@ import Atomics
 /// Each case maps to a distinct `Layer` subclass.  The raw string value is
 /// persisted inside `.smodel` files so names must not be changed.
 public enum EncodingType: String, Codable {
-  case leakyRelu,
-       relu,
-       sigmoid,
-       softmax,
-       swish,
-       tanh,
-       batchNormalize,
-       conv2d,
-       dense,
-       dropout,
-       flatten,
-       maxPool,
-       reshape,
-       transConv2d,
-       layerNormalize,
-       lstm,
-       embedding,
-       avgPool,
-       selu,
-       resNet,
-       globalAvgPool,
-       depthwiseConv2d,
-       instanceNorm,
-       rexNet,
-       add,
-       multiply,
-       subtract,
-       divide,
-       mish,
-       prelu,
-       none
+  /// Leaky ReLU activation layer.
+  case leakyRelu
+  /// ReLU activation layer.
+  case relu
+  /// Sigmoid activation layer.
+  case sigmoid
+  /// Softmax activation layer.
+  case softmax
+  /// Swish activation layer.
+  case swish
+  /// Tanh activation layer.
+  case tanh
+  /// Batch normalization layer.
+  case batchNormalize
+  /// 2D convolution layer.
+  case conv2d
+  /// Fully connected dense layer.
+  case dense
+  /// Dropout regularization layer.
+  case dropout
+  /// Flatten layer.
+  case flatten
+  /// Max pooling layer.
+  case maxPool
+  /// Reshape layer.
+  case reshape
+  /// Transposed 2D convolution (deconvolution) layer.
+  case transConv2d
+  /// Layer normalization layer.
+  case layerNormalize
+  /// Long short-term memory (LSTM) layer.
+  case lstm
+  /// Embedding lookup layer.
+  case embedding
+  /// Average pooling layer.
+  case avgPool
+  /// Scaled ELU activation layer.
+  case selu
+  /// ResNet skip-connection block.
+  case resNet
+  /// Global average pooling layer.
+  case globalAvgPool
+  /// Depthwise separable 2D convolution layer.
+  case depthwiseConv2d
+  /// Instance normalization layer.
+  case instanceNorm
+  /// RexNet building block layer.
+  case rexNet
+  /// Element-wise addition layer.
+  case add
+  /// Element-wise multiplication layer.
+  case multiply
+  /// Element-wise subtraction layer.
+  case subtract
+  /// Element-wise division layer.
+  case divide
+  /// Mish activation layer.
+  case mish
+  /// Parametric ReLU activation layer.
+  case prelu
+  /// Sentinel value indicating no layer type.
+  case none
 }
 
 /// A layer that performs an activation function.

--- a/Sources/Neuron/Layers/LayerNormalize.swift
+++ b/Sources/Neuron/Layers/LayerNormalize.swift
@@ -33,7 +33,16 @@ public final class LayerNormalize: BaseLayer {
 
   /// Coding keys used for encoding and decoding the layer normalization layer.
   public enum CodingKeys: String, CodingKey {
-    case gamma, beta, epsilon, inputSize, linkId
+    /// Key for the learnable gamma scale parameter.
+    case gamma
+    /// Key for the learnable beta shift parameter.
+    case beta
+    /// Key for the epsilon stability term.
+    case epsilon
+    /// Key for the layer's input size.
+    case inputSize
+    /// Key for the layer's stable link identifier.
+    case linkId
   }
   
   /// Default initializer for layer normalization.

--- a/Sources/Neuron/Layers/MaxPool.swift
+++ b/Sources/Neuron/Layers/MaxPool.swift
@@ -25,7 +25,9 @@ public final class MaxPool: BaseLayer {
   }
     
   /// Default initializer for max pooling.
-  /// - Parameter inputSize: Optional input size at this layer. If this is the first layer you will need to set this.
+  /// - Parameters:
+  ///   - inputSize: Optional input size at this layer. If this is the first layer you will need to set this.
+  ///   - linkId: A unique string identifier for this layer link. Defaults to a new UUID string.
   public init(inputSize: TensorSize? = nil,
               linkId: String = UUID().uuidString) {
     super.init(inputSize: inputSize,

--- a/Sources/Neuron/Layers/Reshape.swift
+++ b/Sources/Neuron/Layers/Reshape.swift
@@ -14,8 +14,9 @@ public final class Reshape: BaseLayer {
   
   /// Default initializer for a reshape layer.
   /// - Parameters:
-  ///   - size: The size to reshape to.
+  ///   - size: The target `TensorSize` to reshape the input into.
   ///   - inputSize: Optional input size at this layer. If this is the first layer you will need to set this.
+  ///   - linkId: A unique string identifier for this layer link. Defaults to a new UUID string.
   public init(to size: TensorSize,
               inputSize: TensorSize? = nil,
               linkId: String = UUID().uuidString) {

--- a/Sources/Neuron/Models/Classifier.swift
+++ b/Sources/Neuron/Models/Classifier.swift
@@ -140,13 +140,13 @@ public class Classifier {
     optimizer.isTraining = false
   }
   
-  @discardableResult
   /// Exports the underlying sequential model when available.
   ///
   /// - Parameters:
   ///   - overrite: When `false`, appends a timestamp to avoid overwrite.
   ///   - compress: When `true`, writes compact JSON.
   /// - Returns: URL to exported model, or `nil` when unsupported.
+  @discardableResult
   public func export(overrite: Bool = false, compress: Bool = true) -> URL? {
     if let network = optimizer.trainable as? Sequential {
       return network.export(overrite: overrite, compress: compress)

--- a/Sources/Neuron/Models/GAN.swift
+++ b/Sources/Neuron/Models/GAN.swift
@@ -16,7 +16,10 @@ import NumSwift
 open class GAN {
   /// Indicates whether training data is real or generated (fake).
   public enum TrainingType: String {
-    case real, fake
+    /// The data originates from the real training distribution.
+    case real
+    /// The data was produced by the generator.
+    case fake
   }
 
   /// The optimizer responsible for updating the generator network.
@@ -176,13 +179,13 @@ open class GAN {
     return out.first ?? Tensor()
   }
   
-  @discardableResult
   /// Exports discriminator and generator models.
   ///
   /// - Parameters:
   ///   - overrite: When `false`, appends timestamps to filenames.
   ///   - compress: When `true`, writes compact JSON.
   /// - Returns: Tuple of optional URLs for discriminator and generator models.
+  @discardableResult
   public func export(overrite: Bool = false, compress: Bool = false) -> (discriminator: URL?, generator: URL?) {
     var urls: (URL?, URL?) = (nil, nil)
     if let generatorS = generator.trainable as? Sequential,

--- a/Sources/Neuron/Optimizers/Adam.swift
+++ b/Sources/Neuron/Optimizers/Adam.swift
@@ -56,7 +56,9 @@ public class Adam: BaseOptimizer {
   /// - `none`: No weight decay is applied.
   /// - `decay`: Applies L2 weight decay with the specified scalar coefficient.
   public enum WeightDecay {
+    /// No weight decay is applied during parameter updates.
     case none
+    /// Applies decoupled L2 weight decay with the given scalar coefficient.
     case decay(Tensor.Scalar)
   }
   

--- a/Sources/Neuron/Optimizers/LearningRateSchedulers/LearningRateScheduling.swift
+++ b/Sources/Neuron/Optimizers/LearningRateSchedulers/LearningRateScheduling.swift
@@ -13,7 +13,10 @@ import Foundation
 /// - `batch`: Decay is applied once per batch.
 /// - `epoch`: Decay is applied once per epoch, with an associated integer epoch index.
 public enum LearningRateScheduleStepType: Equatable {
-  case batch, epoch
+  /// Decay is applied once per training batch.
+  case batch
+  /// Decay is applied once per training epoch.
+  case epoch
 }
 
 /// Defines the interface for a combined warmup + decay learning rate schedule.

--- a/Sources/Neuron/Optimizers/LossFunction/LossFunction.swift
+++ b/Sources/Neuron/Optimizers/LossFunction/LossFunction.swift
@@ -12,24 +12,48 @@ import NumSwift
 /// Each case represents a different strategy for measuring prediction error.
 public enum LossFunction {
   /// Mean squared error: average of squared differences between prediction and target.
+  ///
+  /// Formula: `sum((predicted - correct)^2) / N`
   case meanSquareError
   /// Cross-entropy loss used without a preceding Softmax layer.
+  ///
+  /// Use when the network's final layer does NOT include `Softmax`. Applies `−log(p)` directly.
   case crossEntropy
   /// Cross-entropy loss optimized for use with a preceding Softmax layer.
+  ///
+  /// Use when the network's final layer IS a `Softmax`. The derivative simplifies to `predicted − correct`.
   case crossEntropySoftmax
   /// Cross-entropy with label smoothing, parameterized by a smoothing coefficient.
+  ///
+  /// Smooths the one-hot targets by mixing them with a uniform prior, reducing overconfidence.
+  /// The associated value is the smoothing factor `ε ∈ (0, 1)`.
   case crossEntropySoftmaxSmoothing(Tensor.Scalar)
   /// Binary cross-entropy loss used without a preceding Softmax layer.
+  ///
+  /// Suitable for binary or multi-label classification tasks. Does not assume a preceding activation.
   case binaryCrossEntropy
   /// Binary cross-entropy loss optimized for use with a preceding Softmax layer.
+  ///
+  /// Use when the network's final layer IS a `Softmax`. Shares the simplified derivative of `.crossEntropySoftmax`.
   case binaryCrossEntropySoftmax
   /// Wasserstein distance loss used for WGAN training.
+  ///
+  /// The critic returns the raw dot product of predictions and labels (no log). Use `.minimaxBinaryCrossEntropy` for standard GANs.
   case wasserstein
   /// Minimax binary cross-entropy used for standard GAN discriminator training.
+  ///
+  /// Equivalent to binary cross-entropy; typically paired with a sigmoid output layer.
   case minimaxBinaryCrossEntropy
   /// Focal loss with softmax, down-weighting easy examples using `alpha` and `gamma`.
+  ///
+  /// Reduces the relative loss for well-classified examples, focusing training on hard cases.
+  /// - `alpha`: Class-balancing weight factor.
+  /// - `gamma`: Focusing exponent; higher values suppress easy examples more aggressively.
   case focalSoftmax(alpha: Tensor.Scalar, gamma: Tensor.Scalar)
   /// Huber (smooth L1) loss with a transition threshold `delta`.
+  ///
+  /// Behaves like MSE for small errors (`|e| ≤ delta`) and like L1 for large errors,
+  /// making it less sensitive to outliers than pure MSE.
   case huber(delta: Tensor.Scalar)
   
   

--- a/Sources/Neuron/Optimizers/WarmupFunction/WarmupFunction.swift
+++ b/Sources/Neuron/Optimizers/WarmupFunction/WarmupFunction.swift
@@ -9,7 +9,10 @@ import Foundation
 
 /// Represents the current phase of a learning rate warmup schedule.
 public enum WarmupState {
-  case warming, complete
+  /// The warmup schedule is actively ramping the learning rate.
+  case warming
+  /// The warmup schedule has reached the target learning rate and is finished.
+  case complete
 }
 
 /// Defines the interface for learning rate warmup strategies.

--- a/Sources/Neuron/Tensor/Tensor.swift
+++ b/Sources/Neuron/Tensor/Tensor.swift
@@ -1067,8 +1067,9 @@ extension Array where Element == Tensor {
 
 // MARK: - Gradient Extensions
 
+/// Utility operations for working with `Tensor.Gradient` values.
 public extension Tensor.Gradient {
-  
+
   /// Normalizes all weight and bias gradient tensors in place to unit L2 norm.
   func l2NomalizeWeightsAndBiases() {
     weights.forEach { $0.l2Normalize() }
@@ -1198,6 +1199,7 @@ public extension Tensor.Gradient {
 
 // MARK: - Static Factory Methods
 
+/// Static factory and fill utilities for constructing `Tensor` values.
 public extension Tensor {
   /// Creates a tensor whose elements are drawn uniformly at random from `range`.
   ///

--- a/Sources/Neuron/Tensor/Tensor.swift
+++ b/Sources/Neuron/Tensor/Tensor.swift
@@ -128,17 +128,17 @@ public class Tensor: Equatable, Codable {
   }
   
   // MARK: - Flat Indexing Helpers
-  
-  /// Computes the flat index for a given (column, row, depth) coordinate.
+
+  /// Computes the flat storage index for an element at the given (column, row, depth) coordinates.
+  ///
   /// Memory layout: `index = d * rows * columns + r * columns + c`
-  @inline(__always)
-/// Computes the flat storage index for an element at the given (column, row, depth) coordinates.
   ///
   /// - Parameters:
   ///   - c: The column index.
   ///   - r: The row index.
   ///   - d: The depth index.
   /// - Returns: The corresponding flat index into the `storage` array.
+  @inline(__always)
   public func flatIndex(column c: Int, row r: Int, depth d: Int) -> Int {
     d * size.rows * size.columns + r * size.columns + c
   }
@@ -824,7 +824,7 @@ public class Tensor: Equatable, Codable {
 // MARK: - Debug Description
 
 extension Tensor: CustomDebugStringConvertible {
-/// A human-readable description of the tensor, including its shape, label, and formatted values.
+  /// A human-readable description of the tensor, including its shape, label, and formatted values.
   /// Useful for debugging; prints each depth slice with row and column layout.
   public var debugDescription: String {
     var string = """

--- a/Sources/Neuron/Tensor/TensorMath.swift
+++ b/Sources/Neuron/Tensor/TensorMath.swift
@@ -8,6 +8,7 @@
 import Foundation
 import NumSwift
 
+/// Numerical stability helpers for `Float`.
 public extension Float {
   /// A small constant added to denominators and square-roots for numerical stability.
   ///
@@ -19,6 +20,7 @@ public extension Float {
 }
 
 #if arch(arm64)
+/// Numerical stability helpers for `Float16` (arm64 only).
 public extension Float16 {
   /// A small constant added to denominators and square-roots for numerical stability.
   ///
@@ -30,6 +32,7 @@ public extension Float16 {
 }
 #endif
 
+/// Axis-wise reduction and math operations on `Tensor`.
 public extension Tensor {
   /// A closure type that receives a pointer to a contiguous block of scalars and its count,
   /// and returns a single reduced scalar result (e.g., sum, mean, or max).

--- a/Sources/Neuron/Tensor/TensorSize.swift
+++ b/Sources/Neuron/Tensor/TensorSize.swift
@@ -104,6 +104,7 @@ public struct TensorSize: Codable, Equatable, Comparable {
   }
 }
 
+/// Convenience conversion from integer arrays to `TensorSize`.
 public extension Array where Element == Int {
   /// Converts an integer array into a `TensorSize` using `[columns, rows, depth]` ordering.
   var tensorSize: TensorSize {

--- a/Sources/Neuron/Tensor/TensorSize.swift
+++ b/Sources/Neuron/Tensor/TensorSize.swift
@@ -39,7 +39,14 @@ public struct TensorSize: Codable, Equatable, Comparable {
   
   /// Coding keys used for encoding and decoding a `TensorSize` instance.
   public enum CodingKeys: String, CodingKey {
-    case rows, columns, depth, batchCount
+    /// Key for the number of rows.
+    case rows
+    /// Key for the number of columns.
+    case columns
+    /// Key for the depth (channel count).
+    case depth
+    /// Key for the batch count dimension.
+    case batchCount
   }
   
   /// Returns a Boolean value indicating whether the total element count of the left tensor is less than that of the right tensor.

--- a/Sources/Neuron/Tensor/TensorStorage+Arithmetic.swift
+++ b/Sources/Neuron/Tensor/TensorStorage+Arithmetic.swift
@@ -10,6 +10,7 @@ import NumSwift
 
 // MARK: - Element-wise Arithmetic (TensorStorage x TensorStorage)
 
+/// Element-wise arithmetic operators between two `TensorStorage` instances.
 public extension TensorStorage {
 
   /// Returns element-wise sum of two storages, operating on the shorter count.
@@ -47,6 +48,7 @@ public extension TensorStorage {
 
 // MARK: - Tensor.Scalar Arithmetic (TensorStorage x Tensor.Scalar)
 
+/// Arithmetic operators between a `TensorStorage` and a `Tensor.Scalar`.
 public extension TensorStorage {
 
   /// Returns a new storage with `rhs` added to every element.
@@ -80,6 +82,7 @@ public extension TensorStorage {
 
 // MARK: - Tensor.Scalar Arithmetic (Tensor.Scalar x TensorStorage)
 
+/// Reverse arithmetic operators with a `Tensor.Scalar` on the left-hand side.
 public extension TensorStorage {
 
   /// Returns a new storage with every element multiplied by the scalar `lhs`.
@@ -113,6 +116,7 @@ public extension TensorStorage {
 
 // MARK: - Reductions
 
+/// Scalar reduction properties over all elements in a `TensorStorage`.
 public extension TensorStorage {
 
   /// Sum of all elements.
@@ -136,6 +140,7 @@ public extension TensorStorage {
 
 // MARK: - Unary Operations
 
+/// Unary element-wise operations on `TensorStorage`.
 public extension TensorStorage {
 
   /// Returns a new TensorStorage with every element negated.

--- a/Sources/Neuron/Tokenizers/Tokenizing.swift
+++ b/Sources/Neuron/Tokenizers/Tokenizing.swift
@@ -68,9 +68,13 @@ open class BaseTokenizer: Tokenizing {
   
   /// Coding keys used for encoding and decoding the tokenizer's properties.
   public enum CodingKeys: String, CodingKey {
+    /// Key for the array of learned byte-pair merge rules.
     case mergeRules
+    /// Key for the token-to-ID vocabulary dictionary.
     case vocab
+    /// Key for the ID-to-token inverse vocabulary dictionary.
     case inverseVocab
+    /// Key for the target vocabulary size used during training.
     case targetVocabSize
   }
 
@@ -224,7 +228,6 @@ open class BaseTokenizer: Tokenizing {
   }
   
   
-  @discardableResult
   /// Exports the trainable as a `.stkns` file.
   ///
   /// - Parameters:
@@ -232,6 +235,7 @@ open class BaseTokenizer: Tokenizing {
   ///   - overrite: When `false`, appends a timestamp to avoid overwrite.
   ///   - compress: When `true`, emits compact JSON.
   /// - Returns: URL to the exported model file, or `nil` on write failure.
+  @discardableResult
   public func export(name: String?, overrite: Bool, compress: Bool) -> URL? {
     let additional = overrite == false ? "-\(Date().timeIntervalSince1970)" : ""
     

--- a/Sources/Neuron/Trainable/Trainable.swift
+++ b/Sources/Neuron/Trainable/Trainable.swift
@@ -78,6 +78,7 @@ public protocol Trainable: AnyObject, Exportable, CustomDebugStringConvertible {
   func export(name: String?, overrite: Bool, compress: Bool) -> URL?
 }
 
+/// Default implementations provided for all `Trainable` conformers.
 public extension Trainable {
   /// A textual representation of the network structure suitable for debugging.
   ///

--- a/Sources/Neuron/Utilities/Exportable.swift
+++ b/Sources/Neuron/Utilities/Exportable.swift
@@ -10,7 +10,6 @@ import Foundation
 
 /// A type that can be exported to a `.stkns` file on disk.
 public protocol Exportable: Codable {
-  @discardableResult
   /// Exports the trainable as a `.stkns` file.
   ///
   /// - Parameters:
@@ -18,5 +17,6 @@ public protocol Exportable: Codable {
   ///   - overrite: When `false`, appends a timestamp to avoid overwrite.
   ///   - compress: When `true`, emits compact JSON.
   /// - Returns: URL to the exported model file, or `nil` on write failure.
+  @discardableResult
   func export(name: String?, overrite: Bool, compress: Bool) -> URL?
 }

--- a/Sources/Neuron/Utilities/Extensions+Numbers.swift
+++ b/Sources/Neuron/Utilities/Extensions+Numbers.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// Neuron-specific convenience additions to `Int`.
 public extension Int {
   /// Converts the integer to a `Tensor.Scalar` value (`Float` or `Float16` depending on build configuration).
   var asTensorScalar: Tensor.Scalar {
@@ -14,6 +15,7 @@ public extension Int {
   }
 }
 
+/// Multi-dimensional subscript support for 3D scalar arrays.
 public extension Array where Element == [[Tensor.Scalar]] {
   /// Extracts a 3D sub-array using separate column, row, and depth range expressions.
   ///

--- a/Sources/Neuron/Utilities/Extensions+String.swift
+++ b/Sources/Neuron/Utilities/Extensions+String.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// Neuron-specific convenience additions to `String`.
 public extension String {
   /// Returns the string's Unicode scalars as an array of single-character strings.
   var characters: [String] {

--- a/Sources/Neuron/Utilities/Extensions+ThreadSafety.swift
+++ b/Sources/Neuron/Utilities/Extensions+ThreadSafety.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// Convenience locking helper for `NSRecursiveLock`.
 public extension NSRecursiveLock {
   @discardableResult
   /// Executes a closure while holding the recursive lock.
@@ -20,6 +21,7 @@ public extension NSRecursiveLock {
   }
 }
 
+/// Convenience locking helper for `NSLock`.
 public extension NSLock {
   @discardableResult
   /// Executes a closure while holding the lock.

--- a/Sources/Neuron/Utilities/Metrics.swift
+++ b/Sources/Neuron/Utilities/Metrics.swift
@@ -58,6 +58,7 @@ public protocol MetricLogger: AnyObject {
   func addMetric(value: Tensor.Scalar, key: Metric)
 }
 
+/// Default implementations for the `MetricLogger` protocol.
 public extension MetricLogger {
   /// Default metric-recording implementation guarded by a lock.
   ///

--- a/Sources/Neuron/Utilities/Vectorize.swift
+++ b/Sources/Neuron/Utilities/Vectorize.swift
@@ -31,9 +31,9 @@ public protocol Vectorizing: Exportable {
   
   /// The last integer index assigned during vectorization.
   var lastKey: Int { get }
-  /// Value that indicate starting of a vector
+  /// The integer token ID reserved for the start-of-sequence sentinel.
   var start: Int { get }
-  /// Value that indicate ending of a vector
+  /// The integer token ID reserved for the end-of-sequence sentinel.
   var end: Int { get }
   /// The current full vector storage of every value passed in keyed by the `Item`
   var vector: Vector { get }
@@ -77,9 +77,9 @@ public class Vectorizer: Vectorizing, Codable {
   /// after reserving indices for start and end tokens.
   public private(set) var lastKey: Int = 0
   
-  /// Value that indicate starting of a vactor
+  /// The integer token ID reserved for the start-of-sequence sentinel (always `0`).
   public let start: Int = 0
-  /// Value that indicate ending of a vactor
+  /// The integer token ID reserved for the end-of-sequence sentinel (always `1`).
   public let end: Int = 1
 
   /// max index is the first index we can use to identify words

--- a/Sources/Neuron/Utilities/Vectorize.swift
+++ b/Sources/Neuron/Utilities/Vectorize.swift
@@ -16,7 +16,12 @@ import NumSwift
 /// - `end`: Append an end token to the vector.
 /// - `none`: Apply no additional formatting tokens.
 public enum VectorFormat {
-  case start, end, none
+  /// Prepend a start token to the vector.
+  case start
+  /// Append an end token to the vector.
+  case end
+  /// Apply no additional formatting tokens.
+  case none
 }
 
 
@@ -96,9 +101,13 @@ public class Vectorizer: Vectorizing, Codable {
   
   /// Coding keys for encoding and decoding `Vectorizer` state.
   public enum CodingKeys: String, CodingKey {
+    /// Key for the token-to-index vector dictionary.
     case vector
+    /// Key for the last assigned token index.
     case lastKey
+    /// Key for whether start/end encoding tokens are used.
     case startAndEndingEncoding
+    /// Key for the current maximum token index.
     case maxIndex
   }
 


### PR DESCRIPTION
## Summary

Full pass over all 95 Swift files under `Sources/Neuron/` to ensure every `public`/`open` declaration has a `///` doc comment.

### Initial documentation pass (previous commits)
The first pass documented individual declarations across all layer, optimizer, model, tensor, and utility files — adding one-line summaries, `- Parameter:` blocks, `- Returns:` annotations, and `- Throws:` where applicable.

### Final documentation pass (latest commit)
A systematic audit identified 18 `public extension` blocks that lacked doc comments on the extension declaration itself (members within each extension were already documented). The following files were updated:

- **`Tensor/Tensor.swift`** — `Tensor.Gradient` utility extension; `Tensor` static factory extension
- **`Tensor/TensorMath.swift`** — `Float` stability helpers; `Float16` stability helpers (arm64); `Tensor` axis-reduction extension  
- **`Tensor/TensorSize.swift`** — `Array<Int>` → `TensorSize` conversion extension
- **`Tensor/TensorStorage+Arithmetic.swift`** — 5 arithmetic/reduction extension blocks (`TensorStorage × TensorStorage`, `TensorStorage × Scalar`, `Scalar × TensorStorage`, reductions, unary ops)
- **`Trainable/Trainable.swift`** — `Trainable` default implementations extension
- **`Utilities/Extensions+Numbers.swift`** — `Int` convenience extension; `Array<[[Scalar]]>` subscript extension
- **`Utilities/Extensions+String.swift`** — `String` convenience extension
- **`Utilities/Extensions+ThreadSafety.swift`** — `NSRecursiveLock` and `NSLock` locking helpers
- **`Utilities/Metrics.swift`** — `MetricLogger` default implementation extension

No implementation code, signatures, or behavior was modified — documentation only.

## Test plan

- [x] Doc-only changes — no code, signatures, or behavior modified
- [ ] `swift build` passes (Swift not available in this remote execution environment; changes are `///` comments only and cannot affect compilation)
- [ ] `CI=true swift test` passes (same caveat)

https://claude.ai/code/session_01BBEebyyNQ5HJc8tt3tyNRt