### PR TITLE
docs: document public API surface

### DIFF
--- a/Sources/Neuron/Tensor/MetalTensorStorage.swift
+++ b/Sources/Neuron/Tensor/MetalTensorStorage.swift
@@ -110,6 +110,12 @@ public final class MetalTensorStorage: TensorStorage {
     }
   }
 
+  /// Decodes a `MetalTensorStorage` from a single-value JSON array, allocating a new
+  /// MTLBuffer-backed buffer on the default system Metal device.
+  ///
+  /// - Parameter decoder: The decoder to read scalar data from.
+  /// - Throws: `DecodingError.dataCorrupted` if no default Metal device is available,
+  ///   or an error if the scalar array cannot be decoded.
   required convenience init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
     let array = try container.decode([Tensor.Scalar].self)

--- a/Sources/Neuron/Tensor/Tensor.swift
+++ b/Sources/Neuron/Tensor/Tensor.swift
@@ -12,7 +12,9 @@ import NumSwiftC
 /// A protocol that wraps a `RangeExpression<Int>` for use in tensor subscript operations.
 /// Conforming types provide a `range` property used to slice tensor dimensions.
 public protocol TensorRange {
+  /// The concrete `RangeExpression<Int>` type used by a conforming type's `range` property.
   associatedtype T: RangeExpression<Int>
+  /// The range expression describing which indices along a tensor dimension are selected.
   var range: T { get }
 }
 

--- a/Sources/Neuron/Tensor/TensorMath.swift
+++ b/Sources/Neuron/Tensor/TensorMath.swift
@@ -376,6 +376,15 @@ public extension Tensor {
     return Tensor(storage: resultStorage, size: selfSize, context: context)
   }
   
+  /// Creates the backpropagation context for element-wise division of `self` by `value`.
+  ///
+  /// The gradient with respect to `value` (the denominator) is `-gradient * self / value^2`;
+  /// the gradient with respect to `self` (the numerator) is `gradient / value`. When `self`
+  /// and `value` share a computation graph, the computed gradient is also registered as a
+  /// branch gradient on the shared node.
+  ///
+  /// - Parameter value: The tensor `self` is being divided by.
+  /// - Returns: A `TensorContext` that computes the correct gradient depending on `wrt`.
   func divideContext(value: Tensor) -> TensorContext {
     let branchNode: Tensor? = if sharesGraph(with: value) {
       if self.graphChain.contains(value.id) {
@@ -422,6 +431,14 @@ public extension Tensor {
     return Tensor(storage: storage.copy(), size: size, context: divideContext(value: value))
   }
   
+  /// Creates the backpropagation context for element-wise multiplication of `self` by `value`.
+  ///
+  /// The gradient with respect to either operand is the incoming gradient multiplied by the
+  /// other operand's value. When `self` and `value` share a computation graph, the computed
+  /// gradient is also registered as a branch gradient on the shared node.
+  ///
+  /// - Parameter value: The tensor `self` is being multiplied by.
+  /// - Returns: A `TensorContext` that computes the correct gradient depending on `wrt`.
   func multiplyContext(value: Tensor) -> TensorContext {
     let branchNode: Tensor? = if sharesGraph(with: value) {
       if self.graphChain.contains(value.id) {
@@ -468,6 +485,14 @@ public extension Tensor {
     return Tensor(storage: storage.copy(), size: size, context: multiplyContext(value: value))
   }
   
+  /// Creates the backpropagation context for element-wise addition of `self` and `value`.
+  ///
+  /// The gradient with respect to both operands is simply the incoming gradient, passed
+  /// through unchanged. When `self` and `value` share a computation graph, the gradient is
+  /// also registered as a branch gradient on the shared node.
+  ///
+  /// - Parameter value: The tensor being added to `self`.
+  /// - Returns: A `TensorContext` that passes the incoming gradient through to both operands.
   func addContext(value: Tensor) -> TensorContext {
     let branchNode: Tensor? = if sharesGraph(with: value) {
       /*
@@ -529,6 +554,15 @@ public extension Tensor {
     return Tensor(storage: storage.copy(), size: size, context: addContext(value: value))
   }
   
+  /// Creates the backpropagation context for element-wise subtraction of `value` from `self`.
+  ///
+  /// The gradient with respect to `self` is the incoming gradient unchanged; the gradient
+  /// with respect to `value` is the incoming gradient negated. When `self` and `value` share
+  /// a computation graph, the computed gradient is also registered as a branch gradient on
+  /// the shared node.
+  ///
+  /// - Parameter value: The tensor being subtracted from `self`.
+  /// - Returns: A `TensorContext` that computes the correct gradient depending on `wrt`.
   func subtractContext(value: Tensor) -> TensorContext {
     let branchNode: Tensor? = if sharesGraph(with: value) {
       if self.graphChain.contains(value.id) {


### PR DESCRIPTION
## Summary

Swept every `.swift` file under `Sources/Neuron/` for public/open API declarations missing doc comments. Most of the codebase was already fully documented from prior passes on `develop` (commits like `8d9a859`, `13aad8c`, `a01f57e`, `0e3c5b5`). This pass found and closed the remaining gaps, all in the `Tensor` module:

- **`Sources/Neuron/Tensor/MetalTensorStorage.swift`** — documented the `Decodable` `init(from:)` initializer.
- **`Sources/Neuron/Tensor/Tensor.swift`** — documented the `TensorRange` protocol's `associatedtype T` and `var range` requirements.
- **`Sources/Neuron/Tensor/TensorMath.swift`** — documented four public `Tensor` extension methods that build autograd backpropagation contexts: `divideContext(value:)`, `multiplyContext(value:)`, `addContext(value:)`, `subtractContext(value:)`.

All other modules (Augmenters, Devices, Datasets, Export, Gradient, Helpers, Importers, Initializers, all Layers incl. Activations/LSTM/Embedding, Models, Optimizers incl. DecayFunction/WarmupFunction/LossFunction, remaining Tensor files, Tokenizers, Trainable, Utilities) were verified to already have complete doc coverage on every public/open declaration — no changes needed there.

This is a documentation-only change: no implementation code, signatures, or behavior were modified, and no existing doc comments were altered.

## Test plan

- [x] `git diff` verified as pure `///` comment additions with zero code changes.
- [ ] `swift build` / `CI=true swift test` — **not run**: no Swift toolchain is available in this execution environment. Given the change is strictly additive doc comments with no code touched, compilation risk is minimal, but a CI run or local verification is recommended before merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AGGaDNaQDaa4vM6HhCjMjs)_