### PR TITLE
Add sparse cross entropy loss function

### DIFF
--- a/Sources/Neuron/Optimizers/LossFunction/LossFunction.swift
+++ b/Sources/Neuron/Optimizers/LossFunction/LossFunction.swift
@@ -28,6 +28,22 @@ public enum LossFunction {
   /// Smooths the one-hot targets by mixing them with a uniform prior, reducing overconfidence.
   /// The associated value is the smoothing factor `ε ∈ (0, 1)`.
   case crossEntropySoftmaxSmoothing(Tensor.Scalar)
+  /// Sparse categorical cross-entropy used without a preceding Softmax layer.
+  ///
+  /// Behaves like `.crossEntropy` but expects the label to be a tensor of **integer class
+  /// indices** rather than a one-hot encoded distribution. This avoids materializing large
+  /// one-hot label tensors when the number of classes is high.
+  ///
+  /// The label tensor is expected to carry one class index per prediction distribution. For a
+  /// prediction of size `(columns: C, rows: R, depth: D)` the label should be of size
+  /// `(columns: 1, rows: R, depth: D)`, where each value is the target class index in `0..<C`.
+  case sparseCrossEntropy
+  /// Sparse categorical cross-entropy optimized for use with a preceding Softmax layer.
+  ///
+  /// Behaves like `.crossEntropySoftmax` (its derivative simplifies to `predicted − oneHot(index)`)
+  /// but expects the label to be a tensor of **integer class indices** rather than a one-hot
+  /// encoded distribution. See `.sparseCrossEntropy` for the expected label layout.
+  case sparseCrossEntropySoftmax
   /// Binary cross-entropy loss used without a preceding Softmax layer.
   ///
   /// Suitable for binary or multi-label classification tasks. Does not assume a preceding activation.
@@ -66,6 +82,15 @@ public enum LossFunction {
   ///   eg. [[[1, 0], [0, 1]]] = 2 classes
   /// - Returns: The loss as a tensor object.
   public func calculate(_ predicted: Tensor, correct: Tensor) -> Tensor {
+    // Sparse variants accept a label tensor of integer class indices whose shape intentionally
+    // differs from the prediction, so they are handled before the one-hot shape check.
+    switch self {
+    case .sparseCrossEntropy, .sparseCrossEntropySoftmax:
+      return calculateSparse(predicted, correct: correct)
+    default:
+      break
+    }
+
     guard predicted.shape == correct.shape else {
       fatalError("predicted shape does not match correct shape")
     }
@@ -99,6 +124,47 @@ public enum LossFunction {
     }
     
     // Output shape: each depth has 1 row with `rows` columns (matching how rows map to loss values)
+    let resultSize = TensorSize(rows: 1, columns: rows, depth: depth)
+    return Tensor(storage: resultStorage, size: resultSize)
+  }
+
+  /// Calculates the sparse categorical cross-entropy loss.
+  ///
+  /// - Parameters:
+  ///   - predicted: Predicted probability distributions of size `(columns: C, rows: R, depth: D)`.
+  ///   - correct: Integer class indices of size `(columns: 1, rows: R, depth: D)`; each value
+  ///     is the target class index in `0..<C` for the corresponding distribution.
+  /// - Returns: A tensor of per-distribution losses of size `(columns: R, rows: 1, depth: D)`,
+  ///   mirroring the layout produced by the one-hot cross-entropy path.
+  private func calculateSparse(_ predicted: Tensor, correct: Tensor) -> Tensor {
+    let size = predicted.size
+    let depth = size.depth
+    let rows = size.rows
+    let cols = size.columns
+
+    let expectedLabelCount = depth * rows
+    guard correct.storage.count >= expectedLabelCount else {
+      fatalError("sparse cross entropy expects \(expectedLabelCount) class indices, received \(correct.storage.count)")
+    }
+
+    let resultStorage = TensorStorage.create(count: depth * rows)
+    let depthScalar = Tensor.Scalar(depth)
+
+    for d in 0..<depth {
+      let depthOffset = d * rows * cols
+      let labelDepthOffset = d * rows
+      for r in 0..<rows {
+        let classIndex = Int(correct.storage[labelDepthOffset + r])
+        guard classIndex >= 0 && classIndex < cols else {
+          fatalError("sparse cross entropy class index \(classIndex) is out of range 0..<\(cols)")
+        }
+
+        let p = predicted.storage[depthOffset + r * cols + classIndex]
+        let loss = (-1 * Tensor.Scalar.log(p + .stabilityFactor)) / depthScalar
+        resultStorage[d * rows + r] = loss
+      }
+    }
+
     let resultSize = TensorSize(rows: 1, columns: rows, depth: depth)
     return Tensor(storage: resultStorage, size: resultSize)
   }
@@ -180,6 +246,51 @@ public enum LossFunction {
          .binaryCrossEntropySoftmax:
       //only if Softmax is the modifier
       return predicted - correct
+
+    case .sparseCrossEntropySoftmax:
+      // Equivalent to the one-hot softmax derivative `predicted - correct`, but the one-hot
+      // vector is reconstructed on the fly from the sparse class indices.
+      let size = predicted.size
+      let cols = size.columns
+      let rows = size.rows
+      let depth = size.depth
+
+      let result = predicted.storage.copy()
+      for d in 0..<depth {
+        let depthOffset = d * rows * cols
+        let labelDepthOffset = d * rows
+        for r in 0..<rows {
+          let classIndex = Int(correct.storage[labelDepthOffset + r])
+          guard classIndex >= 0 && classIndex < cols else {
+            fatalError("sparse cross entropy class index \(classIndex) is out of range 0..<\(cols)")
+          }
+          let idx = depthOffset + r * cols + classIndex
+          result[idx] = result[idx] - 1
+        }
+      }
+      return Tensor(storage: result, size: size)
+
+    case .sparseCrossEntropy:
+      // Matches `.crossEntropy`: `-1 / p` at the true class index, zero elsewhere.
+      let size = predicted.size
+      let cols = size.columns
+      let rows = size.rows
+      let depth = size.depth
+
+      let result = TensorStorage.create(count: cols * rows * depth)
+      for d in 0..<depth {
+        let depthOffset = d * rows * cols
+        let labelDepthOffset = d * rows
+        for r in 0..<rows {
+          let classIndex = Int(correct.storage[labelDepthOffset + r])
+          guard classIndex >= 0 && classIndex < cols else {
+            fatalError("sparse cross entropy class index \(classIndex) is out of range 0..<\(cols)")
+          }
+          let idx = depthOffset + r * cols + classIndex
+          result[idx] = -1 / (predicted.storage[idx] + .stabilityFactor)
+        }
+      }
+      return Tensor(storage: result, size: size)
       
     case .binaryCrossEntropy,
          .minimaxBinaryCrossEntropy:
@@ -210,6 +321,18 @@ public enum LossFunction {
   ///   - correct: Ground-truth target values for the same sample.
   /// - Returns: Scalar loss value.
   public func calculate(_ predicted: [Tensor.Scalar], correct: [Tensor.Scalar]) -> Tensor.Scalar {
+    // Sparse variants receive a single class index in `correct`, so their element count
+    // intentionally differs from `predicted`. Handle them before the equal-count check.
+    switch self {
+    case .sparseCrossEntropy, .sparseCrossEntropySoftmax:
+      guard let first = correct.first else { return 0 }
+      let classIndex = Int(first)
+      guard classIndex >= 0 && classIndex < predicted.count else { return 0 }
+      return -1 * Tensor.Scalar.log(predicted[classIndex] + .stabilityFactor)
+    default:
+      break
+    }
+
     guard predicted.count == correct.count else {
       return 0
     }
@@ -251,6 +374,11 @@ public enum LossFunction {
       
       return sum / Tensor.Scalar(predicted.count)
       
+    case .sparseCrossEntropy, .sparseCrossEntropySoftmax:
+      // Handled above, before the equal-count guard, because the sparse label carries a single
+      // class index rather than a full one-hot vector.
+      return 0
+
     case .crossEntropySoftmax, .crossEntropy:
       // we just need index of max because we multiply by the label and in one-hot labels
       // all other's result in 0

--- a/Tests/NeuronTests/LossFunctionTests.swift
+++ b/Tests/NeuronTests/LossFunctionTests.swift
@@ -385,6 +385,110 @@ final class LossFunctionTests: XCTestCase {
     XCTAssertEqual(loss, 0.0, accuracy: accuracy)
   }
 
+  // MARK: - Sparse Cross Entropy
+
+  func test_sparseCrossEntropy_calculateScalar() {
+    // correct index = 1, p = 0.7, -log(0.7) ≈ 0.35667
+    let predicted: [Tensor.Scalar] = [0.1, 0.7, 0.2]
+    let correct: [Tensor.Scalar] = [1.0]
+    let loss = LossFunction.sparseCrossEntropy.calculate(predicted, correct: correct)
+    XCTAssertEqual(loss, 0.35667, accuracy: accuracy)
+  }
+
+  func test_sparseCrossEntropy_calculateTensor() {
+    // predicted is a distribution over 3 classes; label is the single class index 1.
+    let predicted = Tensor([0.1, 0.7, 0.2], size: TensorSize(rows: 1, columns: 3, depth: 1))
+    let correct = Tensor([1.0], size: TensorSize(rows: 1, columns: 1, depth: 1))
+    let loss = LossFunction.sparseCrossEntropy.calculate(predicted, correct: correct)
+    XCTAssertEqual(loss.asScalar(), 0.35667, accuracy: accuracy)
+  }
+
+  func test_sparseCrossEntropy_derivative() {
+    // -1/p at the true class index, zero elsewhere: [0, -1/0.7, 0]
+    let size = TensorSize(rows: 1, columns: 3, depth: 1)
+    let predicted = Tensor([0.1, 0.7, 0.2], size: size)
+    let correct = Tensor([1.0], size: TensorSize(rows: 1, columns: 1, depth: 1))
+    let derivative = LossFunction.sparseCrossEntropy.derivative(predicted, correct: correct)
+    let expected = Tensor([0.0, -1.0 / 0.7, 0.0] as Tensor.Value, size: size)
+    XCTAssertTrue(derivative.isValueEqual(to: expected, accuracy: accuracy))
+  }
+
+  func test_sparseCrossEntropy_matchesCrossEntropy() {
+    // Sparse label (index) should produce the same loss as the one-hot cross entropy.
+    let predicted: [Tensor.Scalar] = [0.1, 0.7, 0.2]
+    let sparseLoss = LossFunction.sparseCrossEntropy.calculate(predicted, correct: [1.0])
+    let oneHotLoss = LossFunction.crossEntropy.calculate(predicted, correct: [0.0, 1.0, 0.0])
+    XCTAssertEqual(sparseLoss, oneHotLoss, accuracy: accuracy)
+  }
+
+  func test_sparseCrossEntropy_calculateTensor_multiDepth() {
+    // Verify per-depth losses are computed and divided by depthScalar.
+    let predicted = Tensor([0.1, 0.7, 0.2,   // depth 0
+                            0.2, 0.6, 0.2],   // depth 1
+                           size: TensorSize(rows: 1, columns: 3, depth: 2))
+    let correct = Tensor([1.0, 1.0], size: TensorSize(rows: 1, columns: 1, depth: 2))
+    let loss = LossFunction.sparseCrossEntropy.calculate(predicted, correct: correct)
+    // depth 0: -log(0.7) / 2 ≈ 0.17834
+    // depth 1: -log(0.6) / 2 ≈ 0.25541
+    XCTAssertEqual(loss.shape, [1, 1, 2])
+    XCTAssertEqual(loss.storage[0], 0.17834, accuracy: accuracy)
+    XCTAssertEqual(loss.storage[1], 0.25541, accuracy: accuracy)
+  }
+
+  // MARK: - Sparse Cross Entropy Softmax
+
+  func test_sparseCrossEntropySoftmax_calculateScalar() {
+    // Same forward formula as sparseCrossEntropy
+    let predicted: [Tensor.Scalar] = [0.1, 0.7, 0.2]
+    let correct: [Tensor.Scalar] = [1.0]
+    let loss = LossFunction.sparseCrossEntropySoftmax.calculate(predicted, correct: correct)
+    XCTAssertEqual(loss, 0.35667, accuracy: accuracy)
+  }
+
+  func test_sparseCrossEntropySoftmax_calculateTensor() {
+    let predicted = Tensor([0.1, 0.7, 0.2], size: TensorSize(rows: 1, columns: 3, depth: 1))
+    let correct = Tensor([1.0], size: TensorSize(rows: 1, columns: 1, depth: 1))
+    let loss = LossFunction.sparseCrossEntropySoftmax.calculate(predicted, correct: correct)
+    XCTAssertEqual(loss.asScalar(), 0.35667, accuracy: accuracy)
+  }
+
+  func test_sparseCrossEntropySoftmax_derivative() {
+    // predicted - oneHot(index): [0.1, 0.7-1, 0.2] = [0.1, -0.3, 0.2]
+    let size = TensorSize(rows: 1, columns: 3, depth: 1)
+    let predicted = Tensor([0.1, 0.7, 0.2], size: size)
+    let correct = Tensor([1.0], size: TensorSize(rows: 1, columns: 1, depth: 1))
+    let derivative = LossFunction.sparseCrossEntropySoftmax.derivative(predicted, correct: correct)
+    let expected = Tensor([0.1, -0.3, 0.2], size: size)
+    XCTAssertTrue(derivative.isValueEqual(to: expected, accuracy: accuracy))
+  }
+
+  func test_sparseCrossEntropySoftmax_derivative_matchesOneHot() {
+    // The sparse softmax derivative should equal the one-hot softmax derivative.
+    let size = TensorSize(rows: 1, columns: 3, depth: 1)
+    let predicted = Tensor([0.1, 0.7, 0.2], size: size)
+    let sparseCorrect = Tensor([1.0], size: TensorSize(rows: 1, columns: 1, depth: 1))
+    let oneHotCorrect = Tensor([0.0, 1.0, 0.0], size: size)
+    let sparseDerivative = LossFunction.sparseCrossEntropySoftmax.derivative(predicted, correct: sparseCorrect)
+    let oneHotDerivative = LossFunction.crossEntropySoftmax.derivative(predicted, correct: oneHotCorrect)
+    XCTAssertTrue(sparseDerivative.isValueEqual(to: oneHotDerivative, accuracy: accuracy))
+  }
+
+  func test_sparseCrossEntropySoftmax_derivative_multiDepth() {
+    // Two independent distributions, each with its own class index.
+    let size = TensorSize(rows: 1, columns: 3, depth: 2)
+    let predicted = Tensor([0.1, 0.7, 0.2,   // depth 0, index 1
+                            0.5, 0.3, 0.2],   // depth 1, index 0
+                           size: size)
+    let correct = Tensor([1.0, 0.0], size: TensorSize(rows: 1, columns: 1, depth: 2))
+    let derivative = LossFunction.sparseCrossEntropySoftmax.derivative(predicted, correct: correct)
+    // depth 0: [0.1, 0.7-1, 0.2] = [0.1, -0.3, 0.2]
+    // depth 1: [0.5-1, 0.3, 0.2] = [-0.5, 0.3, 0.2]
+    let expected = Tensor([0.1, -0.3, 0.2,
+                           -0.5, 0.3, 0.2],
+                          size: size)
+    XCTAssertTrue(derivative.isValueEqual(to: expected, accuracy: accuracy))
+  }
+
   // MARK: - Edge Cases
 
   func test_calculateScalar_mismatchedCountReturnsZero() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **sparse categorical cross entropy** loss to `LossFunction`. Two cases are introduced, mirroring the existing `crossEntropy` / `crossEntropySoftmax` pairing:

- `.sparseCrossEntropy` — for use **without** a preceding `Softmax` layer.
- `.sparseCrossEntropySoftmax` — for use **with** a preceding `Softmax` layer (derivative simplifies to `predicted − oneHot(index)`).

Unlike the existing cross entropy losses, the sparse variants expect the label to be a tensor of **integer class indices** rather than a one-hot encoded distribution. This avoids materializing large one-hot label tensors when the number of classes is high.

### Label layout

For a prediction of size `(columns: C, rows: R, depth: D)`, the label tensor should be of size `(columns: 1, rows: R, depth: D)`, where each value is the target class index in `0..<C`.

## Implementation notes

- `calculate(_ predicted: Tensor, correct:)` handles the sparse cases **before** the one-hot `predicted.shape == correct.shape` check, delegating to a new private `calculateSparse` helper. Output loss layout matches the one-hot path (`(columns: R, rows: 1, depth: D)`) and is divided by `depth`.
- `calculate(_ predicted: [Tensor.Scalar], correct:)` handles the single-index label before the equal-count guard: loss is `−log(p[index] + stabilityFactor)`.
- `derivative(...)`:
  - `.sparseCrossEntropySoftmax`: copies `predicted.storage` (COW) and subtracts `1` at the true class index per distribution → equivalent to `predicted − correct`.
  - `.sparseCrossEntropy`: zeroed storage with `−1 / (p + stabilityFactor)` at the true class index, matching `.crossEntropy`.
- Class-index bounds are validated with meaningful `fatalError` messages, consistent with the existing shape-mismatch handling.
- Scalar type usage follows the repo convention (`Tensor.Scalar`, numeric literals, `.stabilityFactor`) so it works under `Float16` quantization.

## Tests

Added `LossFunctionTests` covering both variants:

- Scalar and tensor loss calculation
- Derivatives (non-softmax and softmax)
- Multi-depth loss and derivative
- Equivalence checks vs. the one-hot `crossEntropy` / `crossEntropySoftmax`

## Validation

This package targets macOS/iOS and imports `Metal` (and Apple-only dependencies) without Linux platform guards, so `swift build` / `swift test` cannot run in the Linux cloud environment. The changes were reviewed manually against existing patterns; please rely on macOS CI to run the test suite.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3ce7-a584-7407-b837-cb6d6ff00b2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3ce7-a584-7407-b837-cb6d6ff00b2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

