### PR TITLE
docs: document public API surface

### DIFF
--- a/Sources/Neuron/Initializers.swift
+++ b/Sources/Neuron/Initializers.swift
@@ -215,6 +215,8 @@ public struct Initializer {
   }
 }
 
+/// Adds `Codable` conformance to `Initializer`, encoding/decoding via `CodingKeys` so the
+/// selected `InitializerType` (including its associated `std`/`gain` values) round-trips correctly.
 extension Initializer: Codable {
   /// Encodes the initializer strategy.
   ///

--- a/Sources/Neuron/Layers/Activations/GeLu.swift
+++ b/Sources/Neuron/Layers/Activations/GeLu.swift
@@ -42,6 +42,7 @@ public final class GeLu: BaseActivationLayer {
   /// Encodes GeLU layer configuration.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any values fail to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/Activations/LeakyReLu.swift
+++ b/Sources/Neuron/Layers/Activations/LeakyReLu.swift
@@ -47,6 +47,7 @@ public final class LeakyReLu: BaseActivationLayer {
   /// Encodes LeakyReLU layer configuration.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any values fail to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/Activations/ReLu.swift
+++ b/Sources/Neuron/Layers/Activations/ReLu.swift
@@ -41,6 +41,7 @@ public final class ReLu: BaseActivationLayer {
   /// Encodes ReLU layer configuration.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any values fail to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/Activations/SeLu.swift
+++ b/Sources/Neuron/Layers/Activations/SeLu.swift
@@ -41,6 +41,7 @@ public final class SeLu: BaseActivationLayer {
   /// Encodes SELU layer configuration.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any values fail to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/Activations/Sigmoid.swift
+++ b/Sources/Neuron/Layers/Activations/Sigmoid.swift
@@ -41,6 +41,7 @@ public final class Sigmoid: BaseActivationLayer {
   /// Encodes sigmoid layer configuration.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any values fail to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/Activations/Softmax.swift
+++ b/Sources/Neuron/Layers/Activations/Softmax.swift
@@ -32,6 +32,7 @@ public final class Softmax: BaseActivationLayer {
   /// Encodes softmax layer configuration.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any values fail to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/Activations/Swish.swift
+++ b/Sources/Neuron/Layers/Activations/Swish.swift
@@ -42,6 +42,7 @@ public final class Swish: BaseActivationLayer {
   /// Encodes swish layer configuration.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any values fail to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/Activations/Tanh.swift
+++ b/Sources/Neuron/Layers/Activations/Tanh.swift
@@ -41,6 +41,7 @@ public final class Tanh: BaseActivationLayer {
   /// Encodes tanh layer configuration.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any values fail to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/Add.swift
+++ b/Sources/Neuron/Layers/Add.swift
@@ -18,6 +18,7 @@ public final class Add: ArithmeticLayer {
   /// - Parameter inputSize: The size of the input tensor. Defaults to an empty `TensorSize`.
   /// - Parameter initializer: The weight initializer type to use. Defaults to `.heNormal`.
   /// - Parameter linkId: A unique string identifier for this layer link. Defaults to a new UUID string.
+  /// - Parameter inverse: When `true`, swaps the order of the two tensors passed to the arithmetic operation. Has no visible effect for the commutative `Add` operation. Defaults to `false`.
   /// - Parameter linkTo: The identifier of the layer whose output will be added to this layer's input.
   public init(inputSize: TensorSize = TensorSize(array: []),
               initializer: InitializerType = .heNormal,

--- a/Sources/Neuron/Layers/AvgPool.swift
+++ b/Sources/Neuron/Layers/AvgPool.swift
@@ -49,6 +49,7 @@ public final class AvgPool: BaseLayer {
   /// Encodes average-pooling configuration.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any value fails to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/BatchNormalize.swift
+++ b/Sources/Neuron/Layers/BatchNormalize.swift
@@ -181,6 +181,9 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
   // MARK: - Forward
 
   /// Accumulates per-channel sums for one tensor during synchronized batching.
+  /// - Parameters:
+  ///   - tensor: The tensor whose per-channel sums and sum-of-squares are accumulated.
+  ///   - context: Network execution context carrying batch/thread metadata.
   public override func performThreadBatchingForwardPass(tensor: Tensor, context: NetworkContext) {
     guard isTraining else { return }
     let sliceSize = inputSize.rows * inputSize.columns
@@ -199,6 +202,10 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
   ///
   /// Must be called **after** `forward(tensorBatch:context:)` has accumulated
   /// all batch members via `performThreadBatchingForwardPass`.
+  /// - Parameters:
+  ///   - tensor: Input tensor for this batch member.
+  ///   - context: Network execution context.
+  /// - Returns: Normalized output tensor with attached gradient context.
   public override func forward(tensor: Tensor, context: NetworkContext = .init()) -> Tensor {
     let localIterations = iterations.load(ordering: .relaxed)
 
@@ -233,6 +240,9 @@ public final class BatchNormalize: BaseThreadBatchingLayer {
   // MARK: - Apply
 
   /// Updates gamma/beta, moving stats, then resets batch accumulators.
+  /// - Parameters:
+  ///   - gradients: Weight and bias gradients for this layer (unused; gamma/beta are updated from internally accumulated deltas).
+  ///   - learningRate: Learning rate applied when updating gamma and beta.
   public override func apply(gradients: Optimizer.Gradient, learningRate: Tensor.Scalar) {
     super.apply(gradients: gradients, learningRate: learningRate)
 

--- a/Sources/Neuron/Layers/Conv2d.swift
+++ b/Sources/Neuron/Layers/Conv2d.swift
@@ -20,6 +20,8 @@ public class Conv2d: BaseConvolutionalLayer {
   ///   - filterSize: Size of the filter kernel. Default: `(3,3)`
   ///   - initializer: Weight / filter initializer function. Default: `.heNormal`
   ///   - biasEnabled: Boolean defining if the filters have a bias applied. Default: `false`
+  ///   - linkId: Set this to reference the output of this layer in an arithmetic layer. eg a Shortcut path
+  ///   - encodingType: Serialized layer type identifier. Default: `.conv2d`
   public override init(filterCount: Int,
                        inputSize: TensorSize? = nil,
                        strides: (rows: Int, columns: Int) = (1,1),
@@ -85,6 +87,7 @@ public class Conv2d: BaseConvolutionalLayer {
   /// Encodes convolution configuration and filter parameters.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any value fails to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/Dense.swift
+++ b/Sources/Neuron/Layers/Dense.swift
@@ -72,6 +72,7 @@ public final class Dense: BaseLayer {
   /// Encodes dense layer parameters for persistence.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any value fails to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(weights, forKey: .weights)

--- a/Sources/Neuron/Layers/DepthwiseConv2d.swift
+++ b/Sources/Neuron/Layers/DepthwiseConv2d.swift
@@ -67,6 +67,8 @@ public class DepthwiseConv2d: BaseConvolutionalLayer {
   ///   - initializer: Strategy used to initialise filter weights. Default: `.heNormal`
   ///   - biasEnabled: When `true`, a scalar bias is added to every output element in each channel.
   ///     Default: `false`
+  ///   - linkId: Set this to reference the output of this layer in an arithmetic layer. eg a Shortcut path
+  ///   - encodingType: Serialized layer type identifier. Default: `.depthwiseConv2d`
   public init(inputSize: TensorSize? = nil,
               strides: (rows: Int, columns: Int) = (1,1),
               padding: NumSwift.ConvPadding = .valid,

--- a/Sources/Neuron/Layers/Dropout.swift
+++ b/Sources/Neuron/Layers/Dropout.swift
@@ -26,6 +26,7 @@ public final class Dropout: BaseLayer {
   /// - Parameters:
   ///   - chance: Percent change between 0 and 1 of an input node dropping out
   ///   - inputSize: Optional input size at this layer. If this is the first layer you will need to set this.
+  ///   - linkId: A unique string identifier for this layer link. Defaults to a new UUID string.
   public init(_ chance: Tensor.Scalar,
               inputSize: TensorSize? = nil,
               linkId: String = UUID().uuidString) {
@@ -60,6 +61,7 @@ public final class Dropout: BaseLayer {
   /// Encodes dropout configuration.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any value fails to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/Embedding/Embedding.swift
+++ b/Sources/Neuron/Layers/Embedding/Embedding.swift
@@ -87,6 +87,7 @@ public final class Embedding: BaseLayer {
   /// Encodes embedding parameters and shape metadata.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any values fail to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(weights, forKey: .weights)

--- a/Sources/Neuron/Layers/Flatten.swift
+++ b/Sources/Neuron/Layers/Flatten.swift
@@ -52,6 +52,7 @@ public final class Flatten: BaseLayer {
   /// Encodes flatten layer shape metadata.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any value fails to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/LSTM/LSTM.swift
+++ b/Sources/Neuron/Layers/LSTM/LSTM.swift
@@ -282,6 +282,7 @@ public final class LSTM: BaseLayer {
   /// Encodes LSTM gate/output parameters and topology metadata.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any values fail to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(outputSize, forKey: .outputSize)

--- a/Sources/Neuron/Layers/Layer.swift
+++ b/Sources/Neuron/Layers/Layer.swift
@@ -75,9 +75,10 @@ public enum EncodingType: String, Codable {
   case mish
   /// Parametric ReLU activation layer.
   case prelu
-  
+
+  /// Group normalization layer.
   case groupNormalize
-  
+
   /// Sentinel value indicating no layer type.
   case none
 }

--- a/Sources/Neuron/Models/Utilities/VectorizableDataset.swift
+++ b/Sources/Neuron/Models/Utilities/VectorizableDataset.swift
@@ -15,6 +15,7 @@ public typealias VectorizingDatasetData = (training: [DatasetModel], val: [Datas
 /// Conforming types provide a vectorizer, vocabulary size, and methods
 /// for encoding items as one-hot tensors or index-based tensors.
 public protocol VectorizingDataset {
+  /// The element type this dataset vectorizes, currently fixed to `String`.
   typealias Item = String
   /// The vectorizer used to encode and decode dataset items.
   var vectorizer: Vectorizer { get }

--- a/Sources/Neuron/Tensor/TensorMath.swift
+++ b/Sources/Neuron/Tensor/TensorMath.swift
@@ -1183,6 +1183,10 @@ public extension Tensor {
   }
   
   /// Performs element-wise addition between two tensors with automatic broadcasting support.
+  /// - Parameters:
+  ///   - lhs: The left-hand side tensor.
+  ///   - rhs: The right-hand side tensor, broadcast against `lhs` if its shape allows.
+  /// - Returns: A new `Tensor` containing the element-wise sum, wired into the autograd graph.
   static func +(lhs: Tensor, rhs: Tensor) -> Tensor {
     if let axis = Tensor.axisToApplyAlong(selfSize: lhs.size,
                                           size: rhs.size) {
@@ -1213,6 +1217,10 @@ public extension Tensor {
   }
   
   /// Performs element-wise subtraction between two tensors with automatic broadcasting support.
+  /// - Parameters:
+  ///   - lhs: The tensor to subtract from.
+  ///   - rhs: The tensor to subtract, broadcast against `lhs` if its shape allows.
+  /// - Returns: A new `Tensor` containing the element-wise difference, wired into the autograd graph.
   static func -(lhs: Tensor, rhs: Tensor) -> Tensor {
     if let axis = Tensor.axisToApplyAlong(selfSize: lhs.size,
                                           size: rhs.size) {
@@ -1243,6 +1251,10 @@ public extension Tensor {
   }
   
   /// Performs element-wise multiplication between two tensors with automatic broadcasting support.
+  /// - Parameters:
+  ///   - lhs: The left-hand side tensor.
+  ///   - rhs: The right-hand side tensor, broadcast against `lhs` if its shape allows.
+  /// - Returns: A new `Tensor` containing the element-wise product, wired into the autograd graph.
   static func *(lhs: Tensor, rhs: Tensor) -> Tensor {
     if let axis = Tensor.axisToApplyAlong(selfSize: lhs.size,
                                           size: rhs.size) {
@@ -1280,6 +1292,10 @@ public extension Tensor {
   }
   
   /// Performs element-wise division between two tensors with automatic broadcasting support.
+  /// - Parameters:
+  ///   - lhs: The numerator tensor.
+  ///   - rhs: The denominator tensor, broadcast against `lhs` if its shape allows.
+  /// - Returns: A new `Tensor` containing the element-wise quotient, wired into the autograd graph.
   static func /(lhs: Tensor, rhs: Tensor) -> Tensor {
     if let axis = Tensor.axisToApplyAlong(selfSize: lhs.size,
                                           size: rhs.size) {

--- a/Sources/Neuron/Tensor/TensorSize.swift
+++ b/Sources/Neuron/Tensor/TensorSize.swift
@@ -103,6 +103,7 @@ public struct TensorSize: Codable, Equatable, Comparable {
   ///   - rows: Number that defines the row count
   ///   - columns: Number that defines the column count
   ///   - depth: Number that defines the depth count
+  ///   - batchCount: Number that defines the batch count. Defaults to `1`.
   public init(rows: Int = 0, columns: Int = 0, depth: Int = 0, batchCount: Int = 1) {
     self.rows = rows
     self.columns = columns

--- a/Sources/Neuron/Tensor/TensorStorage.swift
+++ b/Sources/Neuron/Tensor/TensorStorage.swift
@@ -246,6 +246,10 @@ public class TensorStorage {
   }
 
   /// Safe range subscript returning an array, clamping to valid bounds.
+  /// - Parameters:
+  ///   - range: The desired range of indices, which may extend outside the storage's bounds.
+  ///   - defaultValue: The value used to fill positions in `range` that fall outside the storage.
+  /// - Returns: An array of `Tensor.Scalar` values covering `range`, with out-of-bounds positions set to `defaultValue`.
   public subscript(safe range: Range<Int>, defaultValue: Tensor.Scalar) -> [Tensor.Scalar] {
     let clampedLower = Swift.max(range.lowerBound, 0)
     let clampedUpper = Swift.min(range.upperBound, count)
@@ -262,6 +266,10 @@ public class TensorStorage {
   }
 
   /// Safe single-element subscript with default.
+  /// - Parameters:
+  ///   - index: The zero-based position of the element to access, which may be out of bounds.
+  ///   - defaultValue: The value returned when `index` is out of bounds.
+  /// - Returns: The scalar at `index`, or `defaultValue` if `index` is out of range.
   public subscript(safe index: Int, defaultValue: Tensor.Scalar) -> Tensor.Scalar {
     guard index >= 0 && index < count else { return defaultValue }
     return _buffer.pointer[index]


### PR DESCRIPTION
## Summary

This repo's public API had already been documented in several prior passes (see `a01f57e`, `13aad8c`, `8d9a859`, `22e09ec` on `develop`). This PR closes the small set of gaps left behind by code added since the last pass (the `GroupNormalize` layer, the reshape fix, sparse cross-entropy loss):

- Added the missing `- Throws:` bullet to ~14 `encode(to encoder:) throws` methods across activation layers (`GeLu`, `LeakyReLu`, `ReLu`, `SeLu`, `Sigmoid`, `Softmax`, `Swish`, `Tanh`), `Embedding`, `LSTM`, `Add`, `AvgPool`, `Conv2d`, `Dense`, `DepthwiseConv2d`, `Dropout`, `Flatten`.
- Filled in missing initializer parameter docs (`Add.inverse`, `Conv2d.linkId`/`encodingType`, `DepthwiseConv2d.linkId`/`encodingType`, `Dropout.linkId`).
- Added `- Parameters`/`- Returns` blocks to `BatchNormalize`'s forward-pass/apply methods, the `Tensor` `+`/`-`/`*`/`/` operators in `TensorMath.swift`, and the safe subscripts in `TensorStorage.swift`.
- Documented the new `EncodingType.groupNormalize` case in `Layer.swift` (added alongside the `GroupNormalize` layer, previously undocumented).
- Documented `TensorSize.init`'s `batchCount` parameter, `Initializer`'s `Codable` extension, and `VectorizingDataset.Item` typealias.

No implementation code, signatures, or existing prose were changed — this is a comment-only diff (24 files, 62 insertions, 2 deletions; the 2 deletions are trailing-whitespace cleanup on lines adjacent to an added comment).

## Test plan
- [x] Reviewed the full diff (`git diff`) to confirm every change is an added/extended `///` doc comment with no code touched.
- [ ] `swift build` / `CI=true swift test` — a Swift toolchain was not available in this execution environment, so these could not be run locally. Given the change is comment-only, there is no compilation risk, but CI should confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTE3ZkdF3rcMzCKzgyznzT

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTE3ZkdF3rcMzCKzgyznzT)_