### PR TITLE
docs: document public API surface

### DIFF
--- a/Sources/Neuron/Layers/Embedding/Embedding.swift
+++ b/Sources/Neuron/Layers/Embedding/Embedding.swift
@@ -15,6 +15,7 @@ public final class Embedding: BaseLayer {
   ///   - batchLength: Length of the input vector
   ///   - initializer: Weight initializer
   ///   - trainable: Whether or not to update weights
+  ///   - linkId: Unique identifier used to link this layer's weights across serialization. Defaults to a new UUID string.
   public init(inputUnits: Int,
               vocabSize: Int,
               batchLength: Int,
@@ -103,8 +104,10 @@ public final class Embedding: BaseLayer {
   }
   
   /// Forward path for the layer
-  /// - Parameter tensor: Input word as a 3D tensor with size `rows: 1, columns: 1, depth: batchLength`
-  /// Expects a non one-hot encoded input tensor with each depth slice being a single vecorized number.
+  /// - Parameters:
+  ///   - tensor: Input word as a 3D tensor with size `rows: 1, columns: 1, depth: batchLength`.
+  ///     Expects a non one-hot encoded input tensor with each depth slice being a single vecorized number.
+  ///   - context: Network context carrying batch metadata through the forward pass.
   /// - Returns: An output 3D tensor of shape `rows: 1, columns: inputUnits, depth: batchLength`
   public override func forward(tensor: Tensor, context: NetworkContext = .init()) -> Tensor {
     var indicies: [Int] = []

--- a/Sources/Neuron/Layers/GlobalAveragePool.swift
+++ b/Sources/Neuron/Layers/GlobalAveragePool.swift
@@ -10,7 +10,9 @@ import NumSwift
 public final class GlobalAvgPool: BaseLayer {
   /// Creates a global-average-pooling layer.
   ///
-  /// - Parameter inputSize: Optional input shape; if supplied, output shape is derived immediately.
+  /// - Parameters:
+  ///   - inputSize: Optional input shape; if supplied, output shape is derived immediately.
+  ///   - linkId: A unique string identifier for this layer link. Defaults to a new UUID string.
   public init(inputSize: TensorSize = TensorSize(array: []),
               linkId: String = UUID().uuidString) {
     super.init(inputSize: inputSize,
@@ -43,6 +45,7 @@ public final class GlobalAvgPool: BaseLayer {
   /// Encodes global-average-pooling configuration.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any value fails to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/GroupNormalize.swift
+++ b/Sources/Neuron/Layers/GroupNormalize.swift
@@ -114,6 +114,7 @@ public final class GroupNormalize: BaseLayer {
   /// Encodes group-normalization parameters.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any value fails to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/InstanceNormalize.swift
+++ b/Sources/Neuron/Layers/InstanceNormalize.swift
@@ -94,6 +94,7 @@ public final class InstanceNormalize: BaseLayer {
   /// Encodes layer-normalization parameters.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any value fails to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/LSTM/LSTM.swift
+++ b/Sources/Neuron/Layers/LSTM/LSTM.swift
@@ -176,9 +176,11 @@ public final class LSTM: BaseLayer {
   ///   - inputUnits: The number of inputs in the LSTM cell
   ///   - batchLength: The number samples (eg. letters) at a given time
   ///   - returnSequence: Determines if the layer returns all outputs of the sequence or just the last output. Default:   `true`
+  ///   - biasEnabled: Whether the gate and output biases are used. Default: `false`
   ///   - initializer: Initializer funciton to use
   ///   - hiddenUnits: Number of hidden use
   ///   - vocabSize: size of the expected vocabulary
+  ///   - linkId: Unique identifier used to link this layer's weights across serialization. Defaults to a new UUID string.
   public init(inputUnits: Int,
               batchLength: Int,
               returnSequence: Bool = true,
@@ -309,7 +311,9 @@ public final class LSTM: BaseLayer {
   
   /// The forward path for the LSTM layer. Should be preceeded by an `Embedding` layer.
   /// Emdedding input size expected is `(rows: 1, columns: inputUnits, depth: batchLength)`
-  /// - Parameter tensor: The `Embedding` input `Tensor`
+  /// - Parameters:
+  ///   - tensor: The `Embedding` input `Tensor`
+  ///   - context: Network context carrying batch metadata through the forward pass.
   /// - Returns: Depending on the state of `returnSequence` it will either returng the whole sequence of size
   /// `(rows: 1, columns: vocabSize, depth: batchLength)` or just the last output of the sequence of size
   /// `(rows: 1, columns: vocabSize, depth: 1)`

--- a/Sources/Neuron/Layers/LayerNormalize.swift
+++ b/Sources/Neuron/Layers/LayerNormalize.swift
@@ -98,6 +98,7 @@ public final class LayerNormalize: BaseLayer {
   /// Encodes layer-normalization parameters.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any value fails to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/MaxPool.swift
+++ b/Sources/Neuron/Layers/MaxPool.swift
@@ -56,6 +56,7 @@ public final class MaxPool: BaseLayer {
   /// Encodes max-pooling layer configuration.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any value fails to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/ResNet.swift
+++ b/Sources/Neuron/Layers/ResNet.swift
@@ -177,6 +177,7 @@ public final class ResNet: BaseLayerGroup {
   /// Encodes residual block configuration and internal path networks.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any value fails to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)

--- a/Sources/Neuron/Layers/Reshape.swift
+++ b/Sources/Neuron/Layers/Reshape.swift
@@ -54,6 +54,7 @@ public final class Reshape: BaseLayer {
   /// Encodes reshape configuration and base layer metadata.
   ///
   /// - Parameter encoder: Encoder used for serialization.
+  /// - Throws: An error if any value fails to encode.
   public override func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(inputSize, forKey: .inputSize)


### PR DESCRIPTION
## Summary

A full sweep of `Sources/Neuron/` (90 files) was performed to fill in any remaining gaps in public API documentation. Most of the codebase was already fully documented from earlier passes (#175, #178, and others on `develop`), so this PR is a small follow-up covering the last few gaps:

- **`Layers/GlobalAveragePool.swift`, `GroupNormalize.swift`, `InstanceNormalize.swift`, `LayerNormalize.swift`, `MaxPool.swift`, `ResNet.swift`, `Reshape.swift`**: added missing `- Throws:` tags on `encode(to:)` overrides, plus a missing `linkId` parameter doc on `GlobalAvgPool.init`.
- **`Layers/Embedding/Embedding.swift`**: added missing `linkId` and `context` parameter docs on `init` / `forward(tensor:context:)`.
- **`Layers/LSTM/LSTM.swift`**: added missing `biasEnabled`, `linkId`, and `context` parameter docs on `init` / `forward(tensor:context:)`.

## Scope

- Doc comments (`///`) only — no implementation code, signatures, or behavior changed.
- Only `public`/`open` declarations were touched; `internal`/`fileprivate`/`private` members were left as-is.
- Existing doc comments were preserved; only missing pieces (parameters, `- Throws:`) were added.

## Verification

- `git diff` confirms every changed line is a `///` comment addition (verified with a diff scan excluding all `///`-only lines — zero non-comment changes).
- The Swift toolchain is not available in this sandboxed CI environment, so `swift build` / `CI=true swift test` could not be run directly here. Given the change is purely additive documentation comments with no code-line modifications, compilation risk is effectively nil, but please confirm CI passes on this PR before merging.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01RqYUwE9SaamiaHbwuancQd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqYUwE9SaamiaHbwuancQd)_