### PR TITLE
docs: document public API surface

### DIFF
--- a/Sources/Neuron/Importers/Importer.swift
+++ b/Sources/Neuron/Importers/Importer.swift
@@ -8,41 +8,77 @@
 import Foundation
 import Logger
 
+/// Marker protocol for the input payload passed to an ``Importer``'s `fetch` method.
 public protocol ImporterPayload: Sendable {}
+
+/// A payload returned by an ``Importer`` containing the imported model.
 public protocol ResultPayload {
+  /// The `Sequential` model produced by the import operation.
   var model: Sequential { get }
 }
 
+/// Describes a type capable of fetching and building a `Sequential` model from some payload source.
 public protocol Importer {
+  /// The input payload type used to locate/fetch the model data.
   associatedtype Payload: ImporterPayload
+  /// The result payload type returned once the model has been built.
   associatedtype ResultingPayload: ResultPayload
+
+  /// Fetches and builds a model for the given payload.
+  /// - Parameters:
+  ///   - payload: The input describing where/how to obtain the model data.
+  ///   - precompile: Whether the resulting model should be compiled immediately after import.
+  /// - Returns: The resulting payload containing the built model.
+  /// - Throws: An error if the fetch or model-building step fails.
   func fetch(payload: Payload, precompile: Bool) async throws -> ResultingPayload
 }
 
+/// The default `ResultPayload` implementation, wrapping only the imported model.
 public struct BaseResultPayload: ResultPayload {
+  /// The `Sequential` model produced by the import operation.
   public let model: Sequential
 }
 
+/// Base class for importers that fetch model data from a source and build a `Sequential` model from it.
+/// Subclass and override `fetch(payload:precompile:)` to implement a concrete import strategy (see `RemoteImporter`).
 public class BaseImporter<Payload: ImporterPayload, ResultingPayload: ResultPayload>: Importer, Logger {
+  /// The logging verbosity level used when reporting import activity.
   public var logLevel: LogLevel = .low
-  
+
+  /// Errors that can occur while importing a model.
   public enum ImporterError: Error {
+    /// The provided URL string could not be parsed into a valid `URL`.
     case invalidURL
+    /// The server response was not valid for the request.
     case invalidResponse
+    /// The downloaded/provided data could not be used to build a model.
     case invalidData
   }
-  
+
+  /// The `URLSession` used to perform network requests.
   public let session: URLSession
-  
+
+  /// Creates a new importer.
+  /// - Parameter session: The `URLSession` used to perform network requests. Defaults to `.shared`.
   public init(session: URLSession = .shared) {
     self.session = session
   }
-  
+
+  /// Fetches and builds a model for the given payload. Must be overridden by subclasses.
+  /// - Parameters:
+  ///   - payload: The input describing where/how to obtain the model data.
+  ///   - precompile: Whether the resulting model should be compiled immediately after import.
+  /// - Returns: The resulting payload containing the built model.
+  /// - Throws: An error if the fetch or model-building step fails.
   public func fetch(payload: Payload, precompile: Bool = false) async throws -> ResultingPayload {
     // override
     fatalError("Do not use the BaseImporter, override this")
   }
 
+  /// Builds a `Sequential` model from raw `.smodel` data.
+  /// - Parameter data: The raw exported model data.
+  /// - Returns: The reconstructed `Sequential` model.
+  /// - Throws: An error if the data cannot be decoded into a valid model.
   public func buildModel(data: Data) throws -> Sequential {
     let network: Result<Sequential, Error> = ExportHelper.buildModel(data)
     

--- a/Sources/Neuron/Importers/Remote.swift
+++ b/Sources/Neuron/Importers/Remote.swift
@@ -9,20 +9,31 @@ import Foundation
 import AppleArchive
 import Accelerate
 
+/// The payload for `RemoteImporter`, specifying the remote URL to download the model from.
 public struct RemotePayload: ImporterPayload, Sendable {
+  /// The URL string pointing to the remote `.smodel` file.
   public let url: String
-  
+
+  /// Creates a new remote payload.
+  /// - Parameter url: The URL string pointing to the remote `.smodel` file.
   public init(url: String) {
     self.url = url
   }
 }
 
+/// Indicates whether a `RemoteImporter` fetch was served from the local cache or downloaded fresh.
 public enum RemoteResultPayloadStatus {
-  case cacheHit, cacheMiss
+  /// The model data was served from the local in-memory cache.
+  case cacheHit
+  /// The model data was downloaded from the network.
+  case cacheMiss
 }
 
+/// The result payload returned by `RemoteImporter`, containing the imported model and its cache status.
 public struct RemoteResultPayload: ResultPayload {
+  /// The `Sequential` model produced by the import operation.
   public let model: Sequential
+  /// Whether the model data was served from cache or freshly downloaded.
   public let status: RemoteResultPayloadStatus
 }
 
@@ -31,6 +42,12 @@ public struct RemoteResultPayload: ResultPayload {
 public final class RemoteImporter: BaseImporter<RemotePayload, RemoteResultPayload> {
   private let cache: NSCache<NSString, NSData> = .init()
   
+  /// Downloads (or serves from cache) the `.smodel` file at `payload.url` and builds the model.
+  /// - Parameters:
+  ///   - payload: The remote URL to fetch the model from.
+  ///   - precompile: Whether the resulting model should be compiled immediately after import.
+  /// - Returns: The resulting payload containing the built model and cache status.
+  /// - Throws: `BaseImporter.ImporterError` if the URL is invalid or the downloaded data is unusable.
   public override func fetch(payload: RemotePayload, precompile: Bool = false) async throws -> RemoteResultPayload {
     guard let url = URL(string: payload.url) else {
       throw ImporterError.invalidURL


### PR DESCRIPTION
## Summary

A full sweep of every `public`/`open` declaration under `Sources/Neuron/` (96 files) found that prior documentation passes (#178, #179) had already covered nearly the entire public API surface (700 of 720 declarations). The only gap was in the `Importers` subsystem, where `RemoteImporter` was made `public` (3d69c15) after the earlier doc passes landed, leaving it and its supporting types undocumented.

This PR closes that gap:

- **`Sources/Neuron/Importers/Importer.swift`**: Added doc comments to `ImporterPayload`, `ResultPayload`, `Importer`, `BaseResultPayload`, `BaseImporter` (including its `logLevel`, `ImporterError`, `session`, `init`, `fetch`, and `buildModel` members).
- **`Sources/Neuron/Importers/Remote.swift`**: Added doc comments to `RemotePayload`, `RemoteResultPayloadStatus`, `RemoteResultPayload`, and `RemoteImporter.fetch`.

No implementation code, signatures, or behavior were changed — doc comments only.

## Test plan

- [x] Reviewed the full diff to confirm only `///` doc comments were added (no code changes)
- [x] `swift build` / `CI=true swift test` could not be run in this environment (Linux container; the package targets iOS/macOS only and depends on Apple-only frameworks like `AppleArchive`/`Accelerate`), so correctness was verified via careful manual review of the diff instead


---
_Generated by [Claude Code](https://claude.ai/code/session_015hPsdomyr1cN2eSenmr9hY)_