### PR TITLE
docs: document public API surface

### DIFF
--- a/Sources/Neuron/Models/Utilities/TokenizableDataset.swift
+++ b/Sources/Neuron/Models/Utilities/TokenizableDataset.swift
@@ -26,12 +26,14 @@ public protocol TokenizingDataset {
   var eosTokenId: Int { get }
   /// The token ID used to pad sequences to a fixed length.
   var padTokenId: Int { get }
-  
+
+  /// The token ID marking the start of a sequence.
   var bosTokenId: Int { get }
-  
+
   /// IDs of tokens that carry no surface text, such as padding and sequence markers.
   var controlTokenIds: Set<Int> { get }
 
+  /// Encodes an item into its full token sequence.
   ///
   /// - Parameter items: Items to vectorize.
   /// - Returns: Tensor containing vectorized token IDs.
@@ -129,6 +131,7 @@ public protocol TokenizingDataset {
 /// Provides default implementations for one-hot encoding, vectorization, decoding,
 /// and model export. Subclasses should override `build()` to supply training data.
 open class TokenizableDataset: TokenizingDataset {
+  /// The concrete tokenizer type used by this dataset.
   public typealias Tokenizer = BPETokenizer
 
   /// The vectorizer used to encode and decode dataset items.

--- a/Sources/Neuron/Tokenizers/Tokenizing.swift
+++ b/Sources/Neuron/Tokenizers/Tokenizing.swift
@@ -12,6 +12,7 @@ public typealias TokenizerCorpus = [String]
 
 /// A protocol that defines tokenization capabilities with support for encoding, decoding, and exporting trained models.
 public protocol Tokenizing: Exportable, Importable {
+  /// The total number of unique tokens in the vocabulary, including merge and control tokens.
   var vocabSize: Int { get }
   /// The token ID used to pad sequences out to a fixed length.
   var padTokenId: Int { get }

--- a/Sources/Neuron/Utilities/Vectorize.swift
+++ b/Sources/Neuron/Utilities/Vectorize.swift
@@ -30,8 +30,11 @@ public enum VectorFormat {
 /// `Vectorizing` provides bidirectional mappings between
 /// items and integer indices, supporting optional start and end token formatting.
 public protocol Vectorizing: Exportable {
+  /// A single vectorizable unit, represented as a string.
   typealias Item = String
+  /// A mapping from items to their assigned integer indices.
   typealias Vector = [Item: Int]
+  /// A mapping from integer indices back to their original items.
   typealias InverseVector = [Int: Item]
   
   /// The last integer index assigned during vectorization.


### PR DESCRIPTION
## Summary

Walked every public/open declaration under `Sources/Neuron/` looking for missing `///` doc comments. The codebase is already thoroughly documented from prior passes (768 public/open declarations found, only a handful of genuine gaps remained). Added doc comments for:

- `Tokenizers/Tokenizing.swift`: `Tokenizing.vocabSize`
- `Models/Utilities/TokenizableDataset.swift`: `TokenizingDataset.bosTokenId`, `TokenizableDataset.Tokenizer` typealias, and a missing one-line summary on `TokenizingDataset.tokenize(_:)`
- `Utilities/Vectorize.swift`: `Vectorizing.Item`, `.Vector`, and `.InverseVector` typealiases

No implementation code, signatures, or behavior were changed — doc comments only.

## Notes

- This sandboxed environment has no Swift toolchain installed (`swift build`/`swift test` are unavailable here), so I could not run the build/test suite directly. The changes are comment-only insertions with no code touched, so compilation risk is effectively nil, but flagging this so CI is the actual verification gate for this PR.
- While preparing this branch, I noticed `develop` had been deleted (it was merged into `main` via #183 a few hours prior, likely auto-deleted on merge). Recreated `develop` from `main`'s current HEAD so this PR — and future work — has a base branch again, per the project's branch strategy in `CLAUDE.md`.

## Test plan

- [ ] CI build and test suite (`CI=true swift test`, `swift build`) — not runnable in this environment, deferred to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYPa4ieU5KXKA2jM2BPmfp

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYPa4ieU5KXKA2jM2BPmfp)_